### PR TITLE
Reject library calls wider than portal capacity

### DIFF
--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -1571,7 +1571,8 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
             // cage_finalize (which records the zombie and sends SIGCHLD) is never
             // called.  Mirror the fork-crash cleanup path (see fork_call error
             // handling) exactly.
-            if let Err(ref _e) = ret {
+            if let Err(ref e) = ret {
+                lind_log!(Default, "Exec'd child error: {:?}", e);
                 cage::cage_record_exit_status(cloned_cageid as u64, cage::ExitStatus::Exited(1));
                 if let Some(c) = cage::get_cage(cloned_cageid as u64) {
                     c.is_dead.store(true, std::sync::atomic::Ordering::Release);

--- a/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
@@ -241,6 +241,23 @@ pub(crate) enum DefinitionType {
     Tag(wasmtime_environ::Tag),
 }
 
+// The library-interposition portal's raw call-site transport is fixed-arity:
+// LIND_MAX_RAW_ARG_SLOTS raw wasm-level argument/cage-id pairs, no more. A
+// wider lowered signature can't be forwarded without silently dropping data,
+// so a portal for such a function is refused outright at link time (see its
+// use below) rather than truncated.
+//
+// This width is independently duplicated -- not derived from a shared
+// definition -- in three other places that must every one of them agree with
+// this value: tools/marshal-infer/src/Infer.cpp's `kMaxRawArgSlots` (the
+// inference-time force_local gate), tools/marshal-gen/gen_grate.py's
+// `LIND_RAW_ARGS_MAX` (the generator's own independent slot-count check),
+// and tests/grate-tests/lib-interpose/lind_marshal.h's `LIND_RAW_ARGS_MAX`
+// (the C dispatch-time abort). Change this value only together with all
+// three; tests/grate-tests/lib-interpose/check_raw_arg_slot_consistency.sh
+// fails the moment any of the four disagree.
+const LIND_MAX_RAW_ARG_SLOTS: usize = 6;
+
 impl<T> Linker<T> {
     /// Creates a new [`Linker`].
     ///
@@ -1100,8 +1117,30 @@ impl<T> Linker<T> {
                     if let Some(cid) = cage_id {
                         let maybe_handler = threei::get_lib_handler(cid, module_name, &name);
                         if let Some((handler_cage_id, fn_ptr)) = maybe_handler {
-                            let name_for_got = name.clone();
                             let func_ty = original_func.ty(&store);
+
+                            // See LIND_MAX_RAW_ARG_SLOTS: reject a wider
+                            // lowered signature outright instead of silently
+                            // truncating it via `.take(LIND_MAX_RAW_ARG_SLOTS)` below.
+                            if func_ty.params().len() > LIND_MAX_RAW_ARG_SLOTS {
+                                let symbol = format!("{module_name}.{name}");
+                                let nparams = func_ty.params().len();
+                                let portal = Func::new(
+                                    &mut store,
+                                    func_ty.clone(),
+                                    move |_, _, _| {
+                                        bail!(
+                                            "lib-3i portal: {symbol} has {nparams} raw ABI argument \
+                                         slots, exceeding the interposition transport's \
+                                         {LIND_MAX_RAW_ARG_SLOTS}-slot capacity"
+                                        );
+                                    },
+                                );
+                                self.insert(key, Definition::new(store.0, Extern::Func(portal)))?;
+                                continue;
+                            }
+
+                            let name_for_got = name.clone();
                             let func_ty_for_portal = func_ty.clone();
                             // Resolved once here (like handler_cage_id/fn_ptr above)
                             // rather than via Caller::get_export inside the portal:
@@ -1125,8 +1164,10 @@ impl<T> Linker<T> {
                                 &mut store,
                                 func_ty,
                                 move |mut caller, params, results| {
-                                    let mut raw = [0u64; 6];
-                                    for (i, v) in params.iter().enumerate().take(6) {
+                                    let mut raw = [0u64; LIND_MAX_RAW_ARG_SLOTS];
+                                    for (i, v) in
+                                        params.iter().enumerate().take(LIND_MAX_RAW_ARG_SLOTS)
+                                    {
                                         raw[i] = match v {
                                             Val::I32(x) => *x as u32 as u64,
                                             Val::I64(x) => *x as u64,

--- a/tests/grate-tests/lib-interpose/check_raw_arg_slot_consistency.sh
+++ b/tests/grate-tests/lib-interpose/check_raw_arg_slot_consistency.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# The interposition transport's raw-ABI-slot capacity (currently 6) is
+# independently hard-coded in four places, not derived from one shared
+# definition -- see each site's own comment for why:
+#   1. tools/marshal-infer/src/Infer.cpp        (kMaxRawArgSlots)
+#   2. tools/marshal-gen/gen_grate.py            (LIND_RAW_ARGS_MAX)
+#   3. tests/grate-tests/lib-interpose/lind_marshal.h (LIND_RAW_ARGS_MAX)
+#   4. src/wasmtime/crates/wasmtime/src/runtime/linker.rs (LIND_MAX_RAW_ARG_SLOTS)
+#
+# This script is the substitute for a real shared/generated constant: it
+# extracts the numeric value from each of the four sources and fails loudly
+# if any of them disagree, rather than letting a partial edit silently
+# desync inference, generation, and the two runtime enforcement points.
+#
+# Usage: tests/grate-tests/lib-interpose/check_raw_arg_slot_consistency.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+fail=0
+
+extract() {
+    local label="$1" file="$2" pattern="$3"
+    local val
+    val="$(grep -oP "$pattern" "$file" | head -1)"
+    if [[ -z "$val" ]]; then
+        echo "MISSING: could not find $label's raw-arg-slot constant in $file"
+        fail=1
+        echo ""
+        return
+    fi
+    echo "$val"
+}
+
+infer_val="$(extract "marshal-infer" \
+    "$REPO_ROOT/tools/marshal-infer/src/Infer.cpp" \
+    'kMaxRawArgSlots\s*=\s*\K\d+')"
+genrate_val="$(extract "gen_grate.py" \
+    "$REPO_ROOT/tools/marshal-gen/gen_grate.py" \
+    'LIND_RAW_ARGS_MAX\s*=\s*\K\d+')"
+header_val="$(extract "lind_marshal.h" \
+    "$SCRIPT_DIR/lind_marshal.h" \
+    '#define\s+LIND_RAW_ARGS_MAX\s+\K\d+')"
+linker_val="$(extract "linker.rs" \
+    "$REPO_ROOT/src/wasmtime/crates/wasmtime/src/runtime/linker.rs" \
+    'LIND_MAX_RAW_ARG_SLOTS:\s*usize\s*=\s*\K\d+')"
+
+if [[ "$fail" -eq 1 ]]; then
+    exit 1
+fi
+
+echo "Infer.cpp:kMaxRawArgSlots       = $infer_val"
+echo "gen_grate.py:LIND_RAW_ARGS_MAX  = $genrate_val"
+echo "lind_marshal.h:LIND_RAW_ARGS_MAX = $header_val"
+echo "linker.rs:LIND_MAX_RAW_ARG_SLOTS = $linker_val"
+
+if [[ "$infer_val" == "$genrate_val" && "$genrate_val" == "$header_val" && "$header_val" == "$linker_val" ]]; then
+    echo "ok    all four raw-arg-slot constants agree ($infer_val)"
+    exit 0
+fi
+
+echo "FAIL  raw-arg-slot constants disagree across inference/generation/runtime"
+exit 1

--- a/tests/grate-tests/lib-interpose/custom-lib/libtoy.c
+++ b/tests/grate-tests/lib-interpose/custom-lib/libtoy.c
@@ -48,6 +48,14 @@ void toy_ctx_close(void *ctx) {
     free(ctx);
 }
 
+// toy_wide_sum7: 7 scalar args -- one raw ABI slot beyond the 6-slot
+// interposition transport. Used to test that a portal for a wider-than-6
+// signature is rejected at link time rather than silently truncated.
+int toy_wide_sum7(int a, int b, int c, int d, int e, int f, int g) {
+    printf("[libtoy] toy_wide_sum7 — this should NOT print if interposed\n");
+    return a + b + c + d + e + f + g;
+}
+
 // toy_argv_len: sum of strlen of each element of a NULL-terminated argv array.
 // Used by the ptr_array (argv) marshalling test.
 int toy_argv_len(const char **argv) {

--- a/tests/grate-tests/lib-interpose/fail-closed/badspec_cage.c
+++ b/tests/grate-tests/lib-interpose/fail-closed/badspec_cage.c
@@ -5,6 +5,8 @@
 // Usage: <mode>
 //   topindex    -- invalid top-level size_arg_index (memmove)
 //   nestedindex -- invalid nested sibling size_arg_index (toy_buf_checksum)
+//   badnargs    -- spec->nargs (7) exceeds LIND_RAW_ARGS_MAX for a function
+//                  whose real signature (toy_mul, 2 args) is well within it
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
@@ -14,6 +16,7 @@
 extern void *memmove(void *dest, const void *src, size_t n);
 struct toy_buffer { const char *data; unsigned len; };
 extern int toy_buf_checksum(const struct toy_buffer *b);
+extern int toy_mul(int a, int b);
 
 int main(int argc, char **argv) {
     if (argc < 2) { fprintf(stderr, "usage: %s <mode>\n", argv[0]); return 2; }
@@ -29,6 +32,8 @@ int main(int argc, char **argv) {
         char data[8] = {0};
         struct toy_buffer b = { .data = data, .len = sizeof(data) };
         r = toy_buf_checksum(&b);
+    } else if (strcmp(mode, "badnargs") == 0) {
+        r = toy_mul(3, 4);
     } else {
         fprintf(stderr, "unknown mode: %s\n", mode);
         return 2;

--- a/tests/grate-tests/lib-interpose/fail-closed/badspec_grate.c
+++ b/tests/grate-tests/lib-interpose/fail-closed/badspec_grate.c
@@ -22,6 +22,7 @@
 extern void *memmove(void *dest, const void *src, size_t n);
 struct toy_buffer { const char *data; unsigned len; };
 extern int toy_buf_checksum(const struct toy_buffer *b);
+extern int toy_mul(int a, int b);
 
 // --- memmove: size_arg_index deliberately out of range (real memmove's n
 // is arg index 2; LIND_RAW_ARGS_MAX is 6, so 99 is unreachably out of
@@ -78,6 +79,32 @@ static uint64_t handler_buf_checksum(uint64_t b, uint64_t a1, uint64_t a2, uint6
 }
 LIND_DEFINE_MARSHAL_HANDLER(toy_buf_checksum, &buf_checksum_bad_spec, handler_buf_checksum)
 
+// --- toy_mul: real signature has 2 raw ABI slots, but the spec below
+// deliberately claims 7 -- exceeding LIND_RAW_ARGS_MAX (6), the transport's
+// actual capacity. This is a corrupt/misconfigured spec, distinct from
+// widesig_grate.c's toy_wide_sum7 (a REAL function whose own signature is
+// too wide, rejected earlier at link/portal-install time before any spec is
+// even consulted). This case is only reachable at all because toy_mul's
+// real signature is narrow enough for the portal to install normally --
+// it's lind_marshal_dispatch's own spec->nargs bound that must catch it. ---
+static struct lind_marshal_spec mul_bad_spec = {
+    .nargs = 7,
+    .args = {
+        { .kind = LIND_ARG_SCALAR }, { .kind = LIND_ARG_SCALAR },
+        { .kind = LIND_ARG_SCALAR }, { .kind = LIND_ARG_SCALAR },
+        { .kind = LIND_ARG_SCALAR }, { .kind = LIND_ARG_SCALAR },
+        { .kind = LIND_ARG_SCALAR },
+    },
+    .ret = { .kind = LIND_RET_SCALAR },
+};
+static uint64_t handler_mul(uint64_t a, uint64_t b, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5) {
+    (void)a2; (void)a3; (void)a4; (void)a5;
+    printf("[Grate|badspec] toy_mul handler ran (should not happen)\n");
+    fflush(stdout);
+    return LIND_RET_INT(toy_mul((int)a, (int)b));
+}
+LIND_DEFINE_MARSHAL_HANDLER(toy_mul, &mul_bad_spec, handler_mul)
+
 // ---------------------------------------------------------------------------
 // Standard grate dispatcher — required export in every grate.
 // ---------------------------------------------------------------------------
@@ -115,8 +142,10 @@ int main(int argc, char *argv[]) {
         if (ret != 0) { fprintf(stderr, "[Grate|badspec] register memmove failed\n"); assert(0); }
         ret = register_lib_handler(cageid, "env", "toy_buf_checksum", grateid, (uint64_t)(uintptr_t)&lind_mh_toy_buf_checksum);
         if (ret != 0) { fprintf(stderr, "[Grate|badspec] register toy_buf_checksum failed\n"); assert(0); }
+        ret = register_lib_handler(cageid, "env", "toy_mul", grateid, (uint64_t)(uintptr_t)&lind_mh_toy_mul);
+        if (ret != 0) { fprintf(stderr, "[Grate|badspec] register toy_mul failed\n"); assert(0); }
 
-        printf("[Grate|badspec] registered 2/2 handlers\n");
+        printf("[Grate|badspec] registered 3/3 handlers\n");
         fflush(stdout);
         if (execv(argv[1], &argv[1]) == -1) { perror("execv"); assert(0); }
     }

--- a/tests/grate-tests/lib-interpose/fail-closed/widesig_cage.c
+++ b/tests/grate-tests/lib-interpose/fail-closed/widesig_cage.c
@@ -1,0 +1,12 @@
+// Cage exercising the >6-raw-ABI-slot portal rejection (widesig_grate.c
+// registers a handler for toy_wide_sum7, whose real signature has 7 slots).
+#include <stdio.h>
+
+extern int toy_wide_sum7(int a, int b, int c, int d, int e, int f, int g);
+
+int main(void) {
+    int r = toy_wide_sum7(1, 2, 3, 4, 5, 6, 7);
+    printf("[Cage|widesig] FAIL: call returned normally (r=%d)\n", r);
+    fflush(stdout);
+    return 0;
+}

--- a/tests/grate-tests/lib-interpose/fail-closed/widesig_grate.c
+++ b/tests/grate-tests/lib-interpose/fail-closed/widesig_grate.c
@@ -1,0 +1,96 @@
+// Grate registering a handler for toy_wide_sum7, whose real signature has 7
+// raw wasm32 ABI slots -- one beyond the interposition transport's 6-slot
+// capacity (register_lib_handler / pass_fptr_to_wt / lind_marshal_dispatch
+// are all fixed at 6 argument pairs). linker.rs rejects the portal install
+// outright for such a wide import, before this grate's handler is ever
+// reachable -- the .nargs=7 spec below is deliberately unreachable, kept
+// only because LIND_DEFINE_MARSHAL_HANDLER requires a spec/handler pair to
+// generate the raw wrapper register_lib_handler needs a pointer to.
+#include <lind_syscall.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdint.h>
+
+#include "../lind_marshal.h"
+
+extern int toy_wide_sum7(int a, int b, int c, int d, int e, int f, int g);
+
+static struct lind_marshal_spec wide_sum7_spec = {
+    .nargs = 7,
+    .args  = {
+        { .kind = LIND_ARG_SCALAR }, { .kind = LIND_ARG_SCALAR },
+        { .kind = LIND_ARG_SCALAR }, { .kind = LIND_ARG_SCALAR },
+        { .kind = LIND_ARG_SCALAR }, { .kind = LIND_ARG_SCALAR },
+        { .kind = LIND_ARG_SCALAR },
+    },
+    .ret = { .kind = LIND_RET_SCALAR },
+};
+static uint64_t handler_wide_sum7(uint64_t a, uint64_t b, uint64_t c,
+                                   uint64_t d, uint64_t e, uint64_t f) {
+    (void)a; (void)b; (void)c; (void)d; (void)e; (void)f;
+    printf("[Grate|widesig] toy_wide_sum7 handler ran (should not happen)\n");
+    fflush(stdout);
+    return 0;
+}
+LIND_DEFINE_MARSHAL_HANDLER(toy_wide_sum7, &wide_sum7_spec, handler_wide_sum7)
+
+// ---------------------------------------------------------------------------
+// Standard grate dispatcher — required export in every grate.
+// ---------------------------------------------------------------------------
+int64_t pass_fptr_to_wt(uint64_t fn_ptr_uint, uint64_t cageid,
+                    uint64_t arg1, uint64_t arg1cage,
+                    uint64_t arg2, uint64_t arg2cage,
+                    uint64_t arg3, uint64_t arg3cage,
+                    uint64_t arg4, uint64_t arg4cage,
+                    uint64_t arg5, uint64_t arg5cage,
+                    uint64_t arg6, uint64_t arg6cage) {
+    if (fn_ptr_uint == 0) {
+        fprintf(stderr, "[Grate|widesig] invalid fn ptr\n");
+        assert(0);
+    }
+    int64_t (*fn)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+              uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+              uint64_t, uint64_t, uint64_t) =
+        (int64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                 uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                 uint64_t, uint64_t, uint64_t))(uintptr_t)fn_ptr_uint;
+    return fn(cageid, arg1, arg1cage, arg2, arg2cage,
+              arg3, arg3cage, arg4, arg4cage,
+              arg5, arg5cage, arg6, arg6cage);
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) { fprintf(stderr, "Usage: %s <cage>\n", argv[0]); assert(0); }
+    int grateid = getpid();
+    pid_t pid = fork();
+    if (pid < 0) { perror("fork"); assert(0); }
+    if (pid == 0) {
+        int cageid = getpid();
+        int ret = register_lib_handler(cageid, "env", "toy_wide_sum7", grateid, (uint64_t)(uintptr_t)&lind_mh_toy_wide_sum7);
+        if (ret != 0) { fprintf(stderr, "[Grate|widesig] register toy_wide_sum7 failed\n"); assert(0); }
+
+        printf("[Grate|widesig] registered 1/1 handlers\n");
+        fflush(stdout);
+        if (execv(argv[1], &argv[1]) == -1) { perror("execv"); assert(0); }
+    }
+    int status;
+    while (wait(&status) > 0) {}
+    int ce = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    fprintf(stderr, "[Grate|widesig] app exited %d\n", ce);
+
+    // A rejected >6-slot portal install traps directly in the cage's own
+    // call to toy_wide_sum7 (no marshalling/dispatch ever runs), so the cage
+    // dies before it can print anything itself -- unlike the other
+    // fail-closed tests, whose cages observe a returned GRATE_ERR value and
+    // report their own PASS/FAIL. A clean exit (0) here means the call
+    // wrongly returned, so the cage's own "FAIL: call returned normally"
+    // line would have printed.
+    if (ce != 0) {
+        printf("[Grate|widesig] PASS: rejected (cage crashed as expected, exit=%d)\n", ce);
+        return 0;
+    }
+    printf("[Grate|widesig] FAIL: cage did not crash (exit=%d)\n", ce);
+    return 1;
+}

--- a/tests/grate-tests/lib-interpose/lind_marshal.h
+++ b/tests/grate-tests/lib-interpose/lind_marshal.h
@@ -809,6 +809,13 @@ static inline uint64_t lind_marshal_dispatch(
     const char                     *_dbg_name)
 {
     (void)_dbg_name;
+    // raw_args and the handler cast below are both fixed at LIND_RAW_ARGS_MAX
+    // slots (the pass_fptr_to_wt/register_lib_handler transport width); a
+    // spec with more args than that would read raw_args out of bounds and
+    // silently drop everything past slot 6 into the handler call.
+    if (spec->nargs > LIND_RAW_ARGS_MAX)
+        _lind_marshal_abort("marshal spec exceeds raw ABI slot capacity");
+
     _lind_marshal_reset();
     _lind_marshal_source_cage = source_cage;
     _lind_marshal_grate_cage  = grate_cage;

--- a/tests/grate-tests/lib-interpose/run_tests.sh
+++ b/tests/grate-tests/lib-interpose/run_tests.sh
@@ -26,6 +26,12 @@ GRATES_DIR="$LINDFS/grates"
 LIND_COMPILE="$REPO_ROOT/scripts/lind_compile"
 LIND_RUN="$REPO_ROOT/scripts/lind_run"
 
+# Route lind_log! diagnostics (Default category is on by default) to stderr,
+# where run_test's output capture can see them, instead of their default
+# destination (a LIND.log file) -- needed for fail-closed-widesig to assert
+# on the rejected-portal diagnostic rather than just a bare exit code.
+export LIND_LOG_OUTPUT=stderr
+
 # auto-libz / auto-libz-spike statically link the real libz implementation
 # (a static grate must resolve every symbol it interposes at link time) from
 # the sibling lind-wasm-apps checkout's zlib build, matching the sibling-repo
@@ -223,6 +229,15 @@ $output"
         pass_test "$name"
     fi
 }
+
+# Pre-flight: the interposition transport's raw-ABI-slot capacity is
+# duplicated (not shared) across inference/generation/runtime -- fail fast,
+# before compiling anything, if those copies have drifted out of sync.
+if ! bash "$SCRIPT_DIR/check_raw_arg_slot_consistency.sh"; then
+    echo "FATAL: raw-arg-slot constant consistency check failed (see above)" >&2
+    exit 1
+fi
+echo ""
 
 echo "=== lib-interpose focused test suite ==="
 echo ""
@@ -559,6 +574,21 @@ run_test "fail-closed-nestedindex" \
     -- \
     -- "[Grate|badspec] toy_buf_checksum handler ran (should not happen)"
 
+# fail-closed-badnargs: toy_mul's real signature is 2 raw ABI slots (well
+# within the transport's 6-slot capacity, so it links normally), but its
+# spec deliberately claims .nargs=7 -- lind_marshal_dispatch's own bound on
+# spec->nargs must reject this itself, since the linker-level check (which
+# only sees the real function's wasm type) cannot.
+GRATE_EXTRA=("$SCRIPT_DIR/custom-lib/libtoy.c")
+run_test "fail-closed-badnargs" \
+    "fail-closed/badspec_cage.c" \
+    "fail-closed/badspec_grate.c" \
+    "env=/lib/libtoy.so" "yes" \
+    "/badspec_cage.cwasm" "badnargs" \
+    -- "[Cage|badspec] PASS: badnargs rejected (GRATE_ERR)" \
+    -- \
+    -- "[Grate|badspec] toy_mul handler ran (should not happen)"
+
 GRATE_EXTRA=("$SCRIPT_DIR/custom-lib/libtoy.c")
 run_test "fail-closed-ptfexhaust" \
     "fail-closed/ptfexhaust_cage.c" \
@@ -568,6 +598,27 @@ run_test "fail-closed-ptfexhaust" \
     -- "[Cage|ptfexhaust] PASS: rejected (GRATE_ERR)" \
     -- \
     -- "[Grate|ptfexhaust] toy_buf_checksum handler ran (should not happen)"
+
+# fail-closed-widesig: toy_wide_sum7 has 7 raw wasm32 ABI slots -- one more
+# than the interposition transport's 6-slot capacity. This is rejected at
+# link/portal-install time (linker.rs), before any grate delegation, so the
+# cage traps on the call itself and can never report its own PASS/FAIL; the
+# parent grate judges success from the cage's exit status instead (see
+# widesig_grate.c). Distinct from the topindex/nestedindex/ptfexhaust cases
+# above, which are rejected inside an already-installed portal's dispatch.
+#
+# The evidence line requires LIND_LOG_OUTPUT=stderr (set above): without it,
+# a bare nonzero cage exit could also mean an unrelated crash, and the test
+# would pass for the wrong reason.
+GRATE_EXTRA=("$SCRIPT_DIR/custom-lib/libtoy.c")
+run_test "fail-closed-widesig" \
+    "fail-closed/widesig_cage.c" \
+    "fail-closed/widesig_grate.c" \
+    "env=/lib/libtoy.so" "yes" \
+    "/widesig_cage.cwasm" \
+    -- "[Grate|widesig] registered 1/1 handlers" "[Grate|widesig] PASS: rejected (cage crashed as expected, exit=1)" \
+    -- "    1: lib-3i portal: env.toy_wide_sum7 has 7 raw ABI argument slots, exceeding the interposition transport's 6-slot capacity" \
+    -- "[Cage|widesig] FAIL: call returned normally" "[Grate|widesig] toy_wide_sum7 handler ran (should not happen)"
 
 DECLARED_TESTS+=("fail-closed")
 

--- a/tests/grate-tests/lib-interpose/zlib-python/zlib-python_grate.c
+++ b/tests/grate-tests/lib-interpose/zlib-python/zlib-python_grate.c
@@ -1,11 +1,18 @@
 // Grate for zlib-python interposition test.
-// Intercepts deflateInit2_, deflate, and deflateEnd so that Python's
-// zlib.compress() returns a fixed 4-byte output b"LIND" regardless of input.
+// Intercepts deflate and deflateEnd so that Python's zlib.compress()
+// returns a fixed 4-byte output b"LIND" regardless of input.
+//
+// deflateInit2_'s real signature lowers to 8 raw wasm32 ABI slots (strm,
+// level, method, windowBits, memLevel, strategy, version, stream_size) --
+// beyond the 6-slot capacity of the register_lib_handler/pass_fptr_to_wt
+// transport, so it is deliberately left uninterposed here and runs as the
+// real zlib call (safe under this test's non-strict preload: the cage's use
+// of libz isn't limited to these 3 symbols). See lind_marshal.h's
+// LIND_RAW_ARGS_MAX and linker.rs's >6-param portal rejection.
 //
 // Uses lind_marshal.h for fully automated argument marshalling — no manual
 // copy_data_between_cages in any handler:
 //
-//   deflateInit2_  → all args SCALAR; handler returns Z_OK
 //   deflate        → z_stream* described as a nested struct (LIND_LO_STRUCT):
 //                    next_out field is PTR OUT sized by sibling avail_out;
 //                    handler writes FIXED_OUTPUT into the shadow buffer and
@@ -86,34 +93,6 @@ static struct lind_layout _zstream_layout = {
     .fields      = _zstream_fields,
     .struct_size = 24,
 };
-
-// ---------------------------------------------------------------------------
-// deflateInit2_: ignore all args, return Z_OK
-// ---------------------------------------------------------------------------
-
-static struct lind_marshal_spec deflate_init2_spec = {
-    .nargs = 8,
-    .args  = {
-        { .kind = LIND_ARG_SCALAR },
-        { .kind = LIND_ARG_SCALAR },
-        { .kind = LIND_ARG_SCALAR },
-        { .kind = LIND_ARG_SCALAR },
-        { .kind = LIND_ARG_SCALAR },
-        { .kind = LIND_ARG_SCALAR },
-        { .kind = LIND_ARG_SCALAR },
-        { .kind = LIND_ARG_SCALAR },
-    },
-    .ret = { .kind = LIND_RET_SCALAR },
-};
-
-static uint64_t handler_deflate_init2(uint64_t a0, uint64_t a1, uint64_t a2,
-                                       uint64_t a3, uint64_t a4, uint64_t a5) {
-    (void)a0; (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
-    printf("[Grate|zlib-python] deflateInit2_ intercepted — returning Z_OK\n");
-    return 0;
-}
-
-LIND_DEFINE_MARSHAL_HANDLER(deflate_init2_, &deflate_init2_spec, handler_deflate_init2)
 
 // ---------------------------------------------------------------------------
 // deflate: fully automated via nested struct layout
@@ -225,16 +204,8 @@ int main(int argc, char *argv[]) {
     if (pid == 0) {
         int cageid = getpid();
 
-        printf("[Grate|zlib-python] registering deflateInit2_ handler for cage %d\n", cageid);
-        int ret = register_lib_handler(cageid, "env", "deflateInit2_",
-            grateid, (uint64_t)(uintptr_t)&lind_mh_deflate_init2_);
-        if (ret != 0) {
-            fprintf(stderr, "[Grate|zlib-python] register deflateInit2_ failed: %d\n", ret);
-            assert(0);
-        }
-
         printf("[Grate|zlib-python] registering deflate handler for cage %d\n", cageid);
-        ret = register_lib_handler(cageid, "env", "deflate",
+        int ret = register_lib_handler(cageid, "env", "deflate",
             grateid, (uint64_t)(uintptr_t)&lind_mh_deflate);
         if (ret != 0) {
             fprintf(stderr, "[Grate|zlib-python] register deflate failed: %d\n", ret);

--- a/tools/marshal-gen/gen_grate.py
+++ b/tools/marshal-gen/gen_grate.py
@@ -47,6 +47,23 @@ SUPPORTED_RET = {"void", "scalar", "ptr_alias_arg", "ptr_into_arg", "handle"}
 SUPPORTED_SIZE = {None, "none", "na", "const", "from_arg", "from_arg_pointee",
                   "cstr", "ptr_array"}
 
+# The interposition runtime's call-site transport is fixed-arity at this many
+# raw wasm-level argument/cage-id pairs (pass_fptr_to_wt / register_lib_handler
+# / lind_marshal_dispatch — see tests/grate-tests/lib-interpose/lind_marshal.h's
+# LIND_RAW_ARGS_MAX). marshal-infer already force_locals anything wider
+# (tools/marshal-infer/src/Infer.cpp's kMaxRawArgSlots/enforceRawArgSlotCap),
+# so this check is normally redundant with a fresh <lib>.marshal.json — it
+# exists as this tool's OWN independent gate against stale, hand-edited, or
+# older JSON that still marks such a function "marshal": generating a handler
+# for one would compile fine and only abort (taking the whole grate process
+# down with it) on the function's first real call.
+#
+# This width is duplicated, not shared, across marshal-infer, gen_grate.py,
+# lind_marshal.h, and linker.rs — all four must be changed together;
+# tests/grate-tests/lib-interpose/check_raw_arg_slot_consistency.sh fails the
+# moment any of them disagree.
+LIND_RAW_ARGS_MAX = 6
+
 
 # Name substrings whose functions cannot be interposed in a static grate:
 #  - setjmp/longjmp: toolchain rejects taking setjmp's address; longjmp restores
@@ -145,6 +162,23 @@ def is_marshalable(f):
     name = f.get("name", "")
     if name in NEVER_INTERPOSE or name in FD_FUNCS \
             or any(s in name for s in NEVER_INTERPOSE_SUBSTR):
+        return False
+    # `args` is already one JSON entry per raw wasm-level ABI slot (sret and
+    # multi-slot params are pre-flattened by marshal-infer), so its length IS
+    # the raw slot count -- see LIND_RAW_ARGS_MAX. Inference should already
+    # have force_localed anything this wide; reaching "marshal" here means the
+    # JSON disagrees with the runtime's transport width (stale, hand-edited,
+    # or produced by an older marshal-infer). Loud and specific, unlike the
+    # generic "dropped" summary below: this is an input-correctness bug, not
+    # routine unsupported-feature filtering, and generating a handler for it
+    # would compile fine and only abort -- taking the whole grate process down
+    # with it -- on the function's first real call.
+    nargs = len(f.get("args", []))
+    if nargs > LIND_RAW_ARGS_MAX:
+        print(f"[gen_grate] REJECTING {name}: needs {nargs} raw ABI slots, "
+              f"exceeding the interposition transport's {LIND_RAW_ARGS_MAX}-slot "
+              f"capacity (marked \"marshal\" despite this -- stale or hand-edited JSON?)",
+              file=sys.stderr)
         return False
     ret = f.get("ret") or {}
     r = ret.get("kind")

--- a/tools/marshal-infer/src/Infer.cpp
+++ b/tools/marshal-infer/src/Infer.cpp
@@ -1147,6 +1147,41 @@ void lowerAbiReturn(const Function &F, FunctionTrees &ft, bool trueSret,
         "synthetic leading pointer argument, not a return value");
 }
 
+// The interposition runtime's call-site transport is fixed-arity: the portal
+// (pass_fptr_to_wt) captures exactly LIND_RAW_ARGS_MAX=6 raw wasm-level
+// argument/cage-id pairs (tests/grate-tests/lib-interpose/lind_marshal.h),
+// and lind_marshal_dispatch aborts the whole grate process if a spec claims
+// more than that -- see the file's `if (spec->nargs > LIND_RAW_ARGS_MAX)
+// _lind_marshal_abort(...)` guard. THIS is the single authoritative source of
+// the "6" below; keep it in sync if that constant ever changes.
+//
+// A function's true raw-slot count is NOT its DWARF/C-level argument count --
+// it's post-ABI-lowering: the synthetic sret/fp128-return pointer (if any)
+// counts as one slot, and any argument with abiSlots>1 (fp128, see above)
+// counts as N slots, not one. Undercounting here is exactly the bug this
+// check exists to prevent: without it, marshal-infer marks a >6-slot function
+// "marshal", gen_grate.py happily registers a handler for it, and the FIRST
+// real call to it aborts the entire grate process at runtime -- taking down
+// every other function sharing that grate, not just the wide one.
+constexpr unsigned kMaxRawArgSlots = 6;
+
+void enforceRawArgSlotCap(FunctionTrees &ft) {
+  unsigned slots = ft.retSretArg ? 1 : 0;
+  for (const auto &p : ft.params)
+    slots += std::max<uint32_t>(1, p->abiSlots);
+  if (slots <= kMaxRawArgSlots)
+    return;
+  ft.forceLocal = true;
+  ft.warnings.push_back(
+      "function needs " + std::to_string(slots) + " raw ABI slots" +
+      (ft.retSretArg ? " (including a synthetic sret/fp128-return pointer)"
+                     : "") +
+      " but the interposition runtime's transport is fixed at " +
+      std::to_string(kMaxRawArgSlots) +
+      " (LIND_RAW_ARGS_MAX) — force_local (a wider spec would abort the "
+      "whole grate process on the first real call, not just fail this one)");
+}
+
 } // namespace
 
 void inferFunction(const Function &F, FunctionTrees &ft) {
@@ -1529,6 +1564,14 @@ void inferFunction(const Function &F, FunctionTrees &ft) {
       }
     }
   }
+
+  // Final, unconditional gate: regardless of how every individual argument/
+  // return classified, a function whose total raw ABI slot count exceeds the
+  // runtime's fixed transport width can never be safely marshalled. Runs last
+  // (not folded into the per-arg loop above) because it needs the FINAL
+  // abiSlots/retSretArg state, which per-arg classification only finishes
+  // determining by the time this function returns.
+  enforceRawArgSlotCap(ft);
 }
 
 } // namespace marshal

--- a/tools/marshal-infer/tests/abi_slot_boundary/five_scalar_sret.c
+++ b/tools/marshal-infer/tests/abi_slot_boundary/five_scalar_sret.c
@@ -1,0 +1,10 @@
+// 5 visible scalar params + a hidden sret pointer (the struct return doesn't
+// fit in registers under the wasm32-wasi ABI, so clang lowers it to a
+// synthetic leading out-pointer argument) = 6 raw ABI slots: right at the
+// cap, must still be accepted.
+struct Big3 { int x, y, z; };
+
+struct Big3 five_scalar_sret(int a, int b, int c, int d, int e) {
+    struct Big3 r = { a + b, c + d, e };
+    return r;
+}

--- a/tools/marshal-infer/tests/abi_slot_boundary/fp128_at_boundary.c
+++ b/tools/marshal-infer/tests/abi_slot_boundary/fp128_at_boundary.c
@@ -1,0 +1,9 @@
+// 4 scalar params + 1 long double (fp128, split into 2 raw i64 slots by the
+// wasm32 backend -- see Infer.cpp's lowerAbiReturn/inferVariadic neighbors
+// for the general fp128-splitting rule) = 4 + 2 = 6 raw ABI slots: right at
+// the cap, must still be accepted. A check counting the long double as one
+// slot (its C-level arity) would wrongly see only 5 and miss the risk one
+// slot later (see fp128_over_boundary.c).
+int fp128_at_boundary(int a, int b, int c, int d, long double x) {
+    return a + b + c + d + (int)x;
+}

--- a/tools/marshal-infer/tests/abi_slot_boundary/fp128_over_boundary.c
+++ b/tools/marshal-infer/tests/abi_slot_boundary/fp128_over_boundary.c
@@ -1,0 +1,6 @@
+// 5 scalar params + 1 long double (2 raw i64 slots) = 5 + 2 = 7 raw ABI
+// slots: one past the cap, must be rejected (force_local). The multi-slot
+// long double is what crosses the boundary here, not an extra scalar param.
+int fp128_over_boundary(int a, int b, int c, int d, int e, long double x) {
+    return a + b + c + d + e + (int)x;
+}

--- a/tools/marshal-infer/tests/abi_slot_boundary/run.sh
+++ b/tools/marshal-infer/tests/abi_slot_boundary/run.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# ABI-edge boundary tests for the raw-ABI-slot cap (LIND_RAW_ARGS_MAX): the
+# hidden sret pointer and multi-slot (fp128) arguments have to be counted in
+# post-ABI-lowering terms, not C-level argument count, or a function that's
+# actually over the transport's capacity slips through as "marshal" and
+# aborts the whole grate process on its first real call (see Infer.cpp's
+# enforceRawArgSlotCap). Five fixtures cross the boundary from different
+# angles:
+#   six_ordinary          6 plain scalars, no sret            -> accepted
+#   five_scalar_sret       5 scalars + hidden sret  (=6)        -> accepted
+#   six_scalar_sret         6 scalars + hidden sret  (=7)        -> rejected
+#   fp128_at_boundary      4 scalars + fp128 (2 slots) (=6)     -> accepted
+#   fp128_over_boundary    5 scalars + fp128 (2 slots) (=7)     -> rejected
+#
+# Each fixture is compiled via `lind_compile --emit-marshal` (the real
+# toolchain entry point -- see CLAUDE.md) and its resulting <fixture>.marshal.json
+# is checked against the expected decision/slot count/warning text. For the
+# "accepted" cases, gen_grate.py's is_marshalable() is also asserted True,
+# confirming eligibility survives into generation, not just inference.
+#
+# A sixth, synthetic case feeds gen_grate.py's is_marshalable() a hand-built
+# dict shaped like STALE JSON: decision:"marshal" with a real 7-entry args
+# array, as a pre-slot-cap-fix marshal-infer (or a hand-edited sidecar) could
+# have produced. This is gen_grate.py's OWN independent slot-count check
+# (distinct from inference's), and this is the only way to test it directly:
+# a freshly-inferred JSON can never actually contain a "marshal"-decision,
+# >6-slot entry, since inference now catches it first.
+#
+# Usage: tools/marshal-infer/tests/abi_slot_boundary/run.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+LIND_COMPILE="$REPO_ROOT/scripts/lind_compile"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1" got="$2" want="$3"
+    if [[ "$got" == "$want" ]]; then
+        echo "  ok    $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  $desc"
+        echo "        got:  $got"
+        echo "        want: $want"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+infer_one() {
+    # Compiles $1.c (from this dir) via the real toolchain entry point and
+    # prints the resulting <name>.marshal.json's path, or nothing on failure.
+    local name="$1"
+    cp "$SCRIPT_DIR/$name.c" "$WORK/$name.c"
+    if ! ( cd "$WORK" && "$LIND_COMPILE" --emit-marshal "$name.c" ) >"$WORK/$name.compile.log" 2>&1; then
+        echo "  FAIL  $name: lind_compile --emit-marshal failed"
+        cat "$WORK/$name.compile.log"
+        FAIL=$((FAIL + 1))
+        return 1
+    fi
+    echo "$WORK/$name.marshal.json"
+}
+
+echo "=== ABI-edge raw-arg-slot boundary tests (real inference) ==="
+
+for case in six_ordinary:marshal:6 five_scalar_sret:marshal:6 \
+            six_scalar_sret:force_local:7 \
+            fp128_at_boundary:marshal:6 fp128_over_boundary:force_local:7
+do
+    name="${case%%:*}"
+    rest="${case#*:}"
+    want_decision="${rest%%:*}"
+    want_slots="${rest#*:}"
+
+    json_path="$(infer_one "$name")" || continue
+    got_decision="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['functions'][0]['decision'])" "$json_path")"
+    check "$name: decision" "$got_decision" "$want_decision"
+
+    if [[ "$want_decision" == "marshal" ]]; then
+        got_nargs="$(python3 -c "import json,sys; print(len(json.load(open(sys.argv[1]))['functions'][0].get('args', [])))" "$json_path")"
+        check "$name: raw slot count (len(args))" "$got_nargs" "$want_slots"
+
+        got_marshalable="$(python3 -c "
+import json, sys
+sys.path.insert(0, '$REPO_ROOT/tools/marshal-gen')
+from gen_grate import is_marshalable
+f = json.load(open(sys.argv[1]))['functions'][0]
+print(is_marshalable(f))
+" "$json_path")"
+        check "$name: is_marshalable() (generated-handler eligibility)" "$got_marshalable" "True"
+    else
+        got_warning="$(python3 -c "
+import json, sys
+f = json.load(open(sys.argv[1]))['functions'][0]
+print(any('needs $want_slots raw ABI slots' in w for w in f.get('warnings', [])))
+" "$json_path")"
+        check "$name: force_local warning cites $want_slots raw ABI slots" "$got_warning" "True"
+    fi
+done
+
+echo ""
+echo "=== gen_grate.py's own independent slot-count check (stale-JSON case) ==="
+
+# A hand-built dict shaped like a "marshal"-decision, 7-arg entry -- what a
+# stale sidecar (predating the inference-side fix, or hand-edited) could
+# still contain. is_marshalable() must reject this itself; it cannot rely on
+# inference having already done so.
+stale_result="$(python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT/tools/marshal-gen')
+from gen_grate import is_marshalable
+stale_fn = {
+    'name': 'stale_wide_fn',
+    'decision': 'marshal',
+    'ret': {'kind': 'scalar'},
+    'args': [{'kind': 'scalar', 'type': 'int', 'size': 4}] * 7,
+}
+print(is_marshalable(stale_fn))
+")"
+check "stale 7-arg 'marshal' entry: is_marshalable() rejects it" "$stale_result" "False"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/tools/marshal-infer/tests/abi_slot_boundary/six_ordinary.c
+++ b/tools/marshal-infer/tests/abi_slot_boundary/six_ordinary.c
@@ -1,0 +1,7 @@
+// Exactly LIND_RAW_ARGS_MAX (6) ordinary scalar slots, no sret, no
+// multi-slot argument -- the plain case a bare "count the C params" reading
+// would also get right. Included as the control alongside the sret/fp128
+// boundary cases, which a plain C-level count gets wrong.
+int six_ordinary(int a, int b, int c, int d, int e, int f) {
+    return a + b + c + d + e + f;
+}

--- a/tools/marshal-infer/tests/abi_slot_boundary/six_scalar_sret.c
+++ b/tools/marshal-infer/tests/abi_slot_boundary/six_scalar_sret.c
@@ -1,0 +1,10 @@
+// 6 visible scalar params + a hidden sret pointer = 7 raw ABI slots: one
+// past the cap, must be rejected (force_local) even though every individual
+// argument is an ordinary int -- the hidden sret slot is what pushes it
+// over, and a check that only counts visible C-level params would miss it.
+struct Big3 { int x, y, z; };
+
+struct Big3 six_scalar_sret(int a, int b, int c, int d, int e, int f) {
+    struct Big3 r = { a + b, c + d, e + f };
+    return r;
+}


### PR DESCRIPTION
## Summary

- reject functions requiring more than six lowered Wasm ABI argument slots during inference, generation, portal dispatch, and marshal dispatch
- count hidden sret parameters and multi-slot `fp128` arguments
- add a consistency gate for the four cross-language transport-capacity definitions
- add strict end-to-end rejection evidence and prohibit wide handler entry
- remove the unsupported eight-slot `deflateInit2_` handler from the Python/zlib focused grate

## Verification

- `make format`
- `make lind-boot`
- marshal-infer build passed
- ABI-boundary inference/generator tests: 14 passed, 0 failed
- harness self-tests: 19 passed, 0 failed
- focused suite: 31 passed, 0 failed, 0 skipped
- raw-slot consistency check passed across C, C++, Python, and Rust
- `git diff --check`

Closes #5.

Current OpenBLAS grate execution and authoritative coverage recomputation are explicitly deferred to the later OpenBLAS workstream; this PR makes no current OpenBLAS coverage claim.
