### PR TITLE
Validate post-call pointer provenance

### DIFF
--- a/tests/grate-tests/lib-interpose/custom-lib/libtoy.c
+++ b/tests/grate-tests/lib-interpose/custom-lib/libtoy.c
@@ -66,3 +66,39 @@ int toy_argv_len(const char **argv) {
     }
     return total;
 }
+
+// --- Functions for the post-call pointer-provenance tests (LIND_RET_PTR_INTO_ARG,
+// out_ptr_into_arg1, and struct-field OUT/cursor copy-back+fixup). ---
+
+// toy_scan_buf: memchr-alike, returns a pointer into buf (or NULL).
+// Used by the LIND_RET_PTR_INTO_ARG provenance test.
+const char *toy_scan_buf(const char *buf, int c, unsigned n) {
+    printf("[libtoy] toy_scan_buf — this should NOT print if interposed\n");
+    for (unsigned i = 0; i < n; i++)
+        if (buf[i] == (char)c) return &buf[i];
+    return 0;
+}
+
+// toy_strtol_like: strtol-alike, writes an endptr into *nptr's own buffer.
+// Used by the out_ptr_into_arg1 (OUT ptr-to-ptr) provenance test.
+long toy_strtol_like(const char *nptr, char **endptr) {
+    printf("[libtoy] toy_strtol_like — this should NOT print if interposed\n");
+    long v = 0;
+    const char *p = nptr;
+    while (*p >= '0' && *p <= '9') { v = v * 10 + (*p - '0'); p++; }
+    if (endptr) *endptr = (char *)p;
+    return v;
+}
+
+// toy_stream_process: a minimal zlib-deflate-alike cursor-advance struct,
+// used by the struct-field OUT/cursor copy-back+fixup provenance test
+// (lind_marshal.h's _lind_post_struct Step 1/Step 3).
+struct toy_stream { const char *next_in; unsigned avail_in; char *next_out; unsigned avail_out; };
+int toy_stream_process(struct toy_stream *s) {
+    printf("[libtoy] toy_stream_process — this should NOT print if interposed\n");
+    unsigned n = s->avail_in < s->avail_out ? s->avail_in : s->avail_out;
+    for (unsigned i = 0; i < n; i++) s->next_out[i] = s->next_in[i];
+    s->next_out += n;
+    s->avail_out -= n;
+    return 0;
+}

--- a/tests/grate-tests/lib-interpose/fail-closed/provenance_cage.c
+++ b/tests/grate-tests/lib-interpose/fail-closed/provenance_cage.c
@@ -1,0 +1,132 @@
+// Cage exercising lind_marshal.h's post-call pointer-provenance checks
+// (issue #7) against provenance_grate.c's three deliberately-adversarial
+// handlers. See that file's header for the shared mode table.
+//
+// Each target loops over every one of its modes in a single call (a
+// _lind_marshal_abort trap inside the grate worker only fails that one
+// interposed call -- see threei::GRATE_ERR's doc -- so the cage process
+// itself keeps running normally across every mode).
+//
+// Usage: <target>
+//   scan    -- LIND_RET_PTR_INTO_ARG   (toy_scan_buf),     modes 0..7
+//   strtol  -- out_ptr_into_arg1        (toy_strtol_like),  modes 0..7
+//   stream  -- struct-field OUT/cursor  (toy_stream_process), modes 0..6
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define LIND_GRATE_ERR (-536805379L)
+
+extern const char *toy_scan_buf(const char *buf, int c, unsigned n);
+extern long toy_strtol_like(const char *nptr, char **endptr);
+struct toy_stream { const char *next_in; unsigned avail_in; char *next_out; unsigned avail_out; };
+extern int toy_stream_process(struct toy_stream *s);
+
+static int run_scan(void) {
+    char buf[8] = "abcdefg";
+    volatile unsigned n = sizeof(buf) - 1;
+    int fail = 0;
+
+    for (int mode = 0; mode <= 7; mode++) {
+        const char *r = toy_scan_buf(buf, mode, n);
+        long rv = (long)(intptr_t)r;
+        switch (mode) {
+            case 0: // null: valid, expect exactly NULL
+                if (r != NULL) { printf("[Cage|provenance] FAIL: scan mode 0 expected NULL, got %ld\n", rv); fail = 1; }
+                break;
+            case 1: // interior: valid, expect exactly &buf[0]
+                if (r != buf) { printf("[Cage|provenance] FAIL: scan mode 1 expected &buf[0], got %ld\n", rv); fail = 1; }
+                break;
+            default: // 2..7: invalid, must be rejected -- toy_scan_buf's
+                     // spec does not set ALLOW_ONE_PAST, so mode 2
+                     // (one-past) is invalid here too, unlike stream's;
+                     // mode 7's candidate has high bits set (see the
+                     // grate's handler comment) and must be rejected before
+                     // narrowing to 32 bits, not aliased into range by it.
+                if (rv != LIND_GRATE_ERR) { printf("[Cage|provenance] FAIL: scan mode %d did not reject (r=%ld)\n", mode, rv); fail = 1; }
+                break;
+        }
+    }
+    if (!fail) printf("[Cage|provenance] PASS: scan (all 8 modes)\n");
+    return fail;
+}
+
+static int run_strtol(void) {
+    int fail = 0;
+
+    for (int mode = 0; mode <= 7; mode++) {
+        // Padded well past _lind_measure_cstr's 64-byte-chunk over-read (it
+        // scans past the NUL looking for one, up to a full chunk at a time)
+        // so that read never runs past this array's own mapped stack slot.
+        char nptr[128] = { 0 };
+        nptr[0] = (char)('0' + mode);
+        size_t len = strlen(nptr) + 1;  // matches the CSTR shadow's allocated length
+        char *endptr = (char *)(intptr_t)0x12345678; // sentinel, must be overwritten
+        long rv = toy_strtol_like(nptr, &endptr);
+        switch (mode) {
+            case 0: // null: valid, expect exactly NULL
+                if (endptr != NULL) { printf("[Cage|provenance] FAIL: strtol mode 0 expected NULL endptr, got %ld\n", (long)(intptr_t)endptr); fail = 1; }
+                break;
+            case 1: // interior: valid, expect exactly nptr
+                if (endptr != nptr) { printf("[Cage|provenance] FAIL: strtol mode 1 expected nptr, got %ld\n", (long)(intptr_t)endptr); fail = 1; }
+                break;
+            case 2: // interior-max (at the NUL, offset len-1): valid,
+                    // expect exactly nptr+len-1 -- the real max endptr value
+                if (endptr != nptr + len - 1) { printf("[Cage|provenance] FAIL: strtol mode 2 expected nptr+len-1, got %ld\n", (long)(intptr_t)endptr); fail = 1; }
+                break;
+            default: // 3..7: invalid, must be rejected -- out_ptr_into_arg1
+                     // here does not set ALLOW_ONE_PAST, so mode 3
+                     // (one-past the NUL) is invalid too, unlike stream's.
+                if (rv != LIND_GRATE_ERR) { printf("[Cage|provenance] FAIL: strtol mode %d did not reject (r=%ld)\n", mode, rv); fail = 1; }
+                break;
+        }
+    }
+    if (!fail) printf("[Cage|provenance] PASS: strtol (all 8 modes)\n");
+    return fail;
+}
+
+static int run_stream(void) {
+    int fail = 0;
+
+    for (int mode = 0; mode <= 6; mode++) {
+        char in[4] = "wxyz";
+        char out[4] = { 0x7f, 0x7f, 0x7f, 0x7f };
+        struct toy_stream s = { .next_in = in, .avail_in = (unsigned)mode, .next_out = out, .avail_out = sizeof(out) };
+        long rv = toy_stream_process(&s);
+        switch (mode) {
+            case 0: // interior, unchanged: valid, must not reject
+            case 1: // one-past: valid, must not reject -- _next_out_fspec
+                    // DOES set ALLOW_ONE_PAST, unlike scan/strtol's specs.
+                if (rv == LIND_GRATE_ERR) { printf("[Cage|provenance] FAIL: stream mode %d wrongly rejected\n", mode); fail = 1; }
+                break;
+            case 2: // null (no output written): valid, expect next_out == NULL
+                if (rv == LIND_GRATE_ERR) { printf("[Cage|provenance] FAIL: stream mode 2 wrongly rejected\n"); fail = 1; }
+                if (s.next_out != NULL) { printf("[Cage|provenance] FAIL: stream mode 2 expected next_out == NULL, got %ld\n", (long)(intptr_t)s.next_out); fail = 1; }
+                break;
+            default: // 3..6: invalid, must be rejected. Also: validation
+                     // must fail before ANY caller-memory write, so s.next_out
+                     // must still be exactly the cage's own original pointer
+                     // here -- never the raw grate shadow address the
+                     // handler left in it (which a blind copy-back-then-
+                     // validate ordering would have exposed before the abort).
+                if (rv != LIND_GRATE_ERR) { printf("[Cage|provenance] FAIL: stream mode %d did not reject (r=%ld)\n", mode, rv); fail = 1; }
+                if (s.next_out != out) { printf("[Cage|provenance] FAIL: stream mode %d leaked a raw pointer into next_out (got %ld)\n", mode, (long)(intptr_t)s.next_out); fail = 1; }
+                break;
+        }
+    }
+    if (!fail) printf("[Cage|provenance] PASS: stream (all 7 modes)\n");
+    return fail;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) { fprintf(stderr, "usage: %s <target>\n", argv[0]); return 2; }
+    const char *target = argv[1];
+
+    if (strcmp(target, "scan") == 0) return run_scan();
+    if (strcmp(target, "strtol") == 0) return run_strtol();
+    if (strcmp(target, "stream") == 0) return run_stream();
+
+    fprintf(stderr, "unknown target: %s\n", target);
+    return 2;
+}

--- a/tests/grate-tests/lib-interpose/fail-closed/provenance_grate.c
+++ b/tests/grate-tests/lib-interpose/fail-closed/provenance_grate.c
@@ -1,0 +1,256 @@
+// Grate exercising lind_marshal.h's post-call pointer-provenance checks
+// (issue #7): a handler is ordinary interposed-library code from the
+// runtime's point of view, and its OUT-direction writes and returns must be
+// treated as untrusted just like any other library data. These handlers
+// deliberately fabricate the values a buggy or adversarial library might
+// leave behind, covering the three post-call translation paths:
+//
+//   toy_scan_buf       LIND_RET_PTR_INTO_ARG        (memchr-style return)
+//   toy_strtol_like    out_ptr_into_arg1            (strtol-style **endptr)
+//   toy_stream_process struct-field OUT/cursor       (zlib next_out-style)
+//
+// Each handler's behavior is selected by a value already present in its own
+// arguments (never a separate "test mode" channel). One-past-the-end
+// (pointer == shadow base + allocated length) is a valid pointer VALUE per
+// C semantics, but never assumed globally permitted -- toy_scan_buf and
+// toy_strtol_like model real memchr/strtol semantics, where a legitimate
+// result is never exactly one-past, so their specs do NOT set
+// LIND_ARGSPEC_ALLOW_ONE_PAST and a one-past value must be REJECTED;
+// toy_stream_process models a cursor-advance OUT buffer (zlib's next_out),
+// where ending up exactly one-past is the ordinary "buffer completely
+// filled" outcome, so its field spec opts in and one-past must be ACCEPTED.
+// See each handler's own mode table below -- they differ per function to
+// match what a real implementation could legitimately produce.
+#include <lind_syscall.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#include "../lind_marshal.h"
+
+// ---------------------------------------------------------------------------
+// toy_scan_buf: LIND_RET_PTR_INTO_ARG
+// ---------------------------------------------------------------------------
+extern const char *toy_scan_buf(const char *buf, int c, unsigned n);
+
+static struct lind_marshal_spec scan_buf_spec = {
+    .nargs = 3,
+    .args = {
+        { .kind = LIND_ARG_PTR, .ptr_direction = LIND_PTR_IN,
+          .size_kind = LIND_SIZE_FROM_ARG, .size_arg_index = 2 },
+        { .kind = LIND_ARG_SCALAR },  // mode (repurposes memchr's "c")
+        { .kind = LIND_ARG_SCALAR },  // n
+    },
+    .ret = { .kind = LIND_RET_PTR_INTO_ARG, .alias_arg_index = 0 },
+};
+
+static char _unrelated_buf1[8];
+
+// Mode table (scan_buf_spec.ret does NOT set ALLOW_ONE_PAST -- a real
+// memchr-alike never legitimately returns exactly one-past):
+//   0 null          1 interior (offset 0)      2 one-past (now INVALID)
+//   3 before-base   4 after-end                5 huge delta
+//   6 unrelated object
+//   7 high-bits-set: a genuinely-64-bit handler_ret whose LOW 32 bits alias
+//     a valid interior address, but whose value as a whole is nowhere near
+//     any real wasm32 address -- a candidate this wide can only reach
+//     lind_marshal_dispatch through this specific path (LIND_RET_PTR_INTO_ARG
+//     hands back the callee's raw uint64_t return value untouched; the
+//     struct-field and out_ptr_into_arg1 paths both read the callee's
+//     value out of a 4-byte shadow slot, so it's naturally already
+//     truncated to 32 bits well before any validation runs).
+static uint64_t handler_scan_buf(uint64_t buf, uint64_t mode, uint64_t n,
+                                  uint64_t a3, uint64_t a4, uint64_t a5) {
+    (void)a3; (void)a4; (void)a5;
+    printf("[Grate|provenance] toy_scan_buf handler ran, mode=%d\n", (int)mode);
+    fflush(stdout);
+    uint8_t *base = (uint8_t *)LIND_AS_PTR(buf);
+    size_t len = LIND_AS_SIZE(n);
+    switch ((int)mode) {
+        case 0: return 0;                                   // null
+        case 1: return LIND_RET_PTR(base);                   // interior
+        case 2: return LIND_RET_PTR(base + len);              // one-past
+        case 3: return LIND_RET_PTR(base - 1);                // before-base
+        case 4: return LIND_RET_PTR(base + len + 1);          // after-end
+        case 7: return LIND_RET_PTR(base) | 0x100000000ULL;   // high bits set
+        case 5: return LIND_RET_PTR(base + 0x40000000u);      // huge delta
+        case 6: return LIND_RET_PTR(_unrelated_buf1);         // unrelated object
+    }
+    return 0;
+}
+LIND_DEFINE_MARSHAL_HANDLER(toy_scan_buf, &scan_buf_spec, handler_scan_buf)
+
+// ---------------------------------------------------------------------------
+// toy_strtol_like: out_ptr_into_arg1 (OUT pointer-to-pointer aliasing arg0)
+// ---------------------------------------------------------------------------
+extern long toy_strtol_like(const char *nptr, char **endptr);
+
+static struct lind_marshal_spec strtol_like_spec = {
+    .nargs = 2,
+    .args = {
+        { .kind = LIND_ARG_PTR, .ptr_direction = LIND_PTR_IN, .size_kind = LIND_SIZE_CSTR },
+        { .kind = LIND_ARG_PTR, .ptr_direction = LIND_PTR_OUT, .size_kind = LIND_SIZE_CONST,
+          .const_size = 4, .out_ptr_into_arg1 = 1 },
+    },
+    .ret = { .kind = LIND_RET_SCALAR },
+};
+
+static char _unrelated_buf2[8];
+
+// Mode table (arg[1]'s out_ptr_into_arg1 spec does NOT set ALLOW_ONE_PAST --
+// a real strtol's endptr never advances past the string's own NUL
+// terminator, which is already the shadow's last INTERIOR byte, not
+// one-past-the-end of the shadow):
+//   0 null                       1 interior (offset 0, start of string)
+//   2 interior-max (at the NUL, offset len-1 -- the real max endptr value)
+//   3 one-past (offset len, now INVALID)   4 before-base
+//   5 after one-past (offset len+1)        6 huge delta
+//   7 unrelated object
+static uint64_t handler_strtol_like(uint64_t nptr, uint64_t endptr_slot,
+                                     uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5) {
+    (void)a2; (void)a3; (void)a4; (void)a5;
+    const char *base = (const char *)LIND_AS_CPTR(nptr);
+    char mode = base[0];  // nptr's first byte selects the scenario
+    printf("[Grate|provenance] toy_strtol_like handler ran, mode='%c'\n", mode);
+    fflush(stdout);
+    size_t len = strlen(base) + 1;  // matches the CSTR shadow's allocated length
+    uint32_t *out = (uint32_t *)LIND_AS_PTR(endptr_slot);
+    uint8_t *val;
+    switch (mode) {
+        case '0': val = 0; break;
+        case '1': val = (uint8_t *)base; break;                    // interior
+        case '2': val = (uint8_t *)base + len - 1; break;           // interior-max (at the NUL)
+        case '3': val = (uint8_t *)base + len; break;                // one-past
+        case '4': val = (uint8_t *)base - 1; break;                  // before-base
+        case '5': val = (uint8_t *)base + len + 1; break;            // after one-past
+        case '6': val = (uint8_t *)base + 0x40000000u; break;        // huge delta
+        case '7': val = (uint8_t *)_unrelated_buf2; break;           // unrelated object
+        default:  val = 0;
+    }
+    *out = (uint32_t)(uintptr_t)val;
+    return 0;
+}
+LIND_DEFINE_MARSHAL_HANDLER(toy_strtol_like, &strtol_like_spec, handler_strtol_like)
+
+// ---------------------------------------------------------------------------
+// toy_stream_process: struct-field OUT/cursor (next_out advance + fixup)
+// ---------------------------------------------------------------------------
+struct toy_stream { const char *next_in; unsigned avail_in; char *next_out; unsigned avail_out; };
+extern int toy_stream_process(struct toy_stream *s);
+
+static struct lind_arg_spec _next_out_fspec = {
+    .kind = LIND_ARG_PTR, .ptr_direction = LIND_PTR_OUT,
+    .size_kind = LIND_SIZE_FROM_ARG, .size_arg_index = 3,  // sibling: avail_out
+    // A completely filled output buffer is the normal outcome for a
+    // cursor-advance OUT buffer, not an edge case (mirrors zlib's next_out).
+    .flags = LIND_ARGSPEC_ALLOW_ONE_PAST,
+};
+static struct lind_field _stream_fields[4] = {
+    { .offset = offsetof(struct toy_stream, next_in),   .spec = NULL,             .touched = 0 },
+    { .offset = offsetof(struct toy_stream, avail_in),  .spec = NULL,             .touched = 0 },
+    { .offset = offsetof(struct toy_stream, next_out),  .spec = &_next_out_fspec, .touched = 1 },
+    { .offset = offsetof(struct toy_stream, avail_out), .spec = NULL,             .touched = 1 },
+};
+static struct lind_layout _stream_layout = {
+    .kind = LIND_LO_STRUCT, .nfields = 4, .fields = _stream_fields,
+    .struct_size = sizeof(struct toy_stream),
+};
+static struct lind_marshal_spec stream_process_spec = {
+    .nargs = 1,
+    .args = {
+        { .kind = LIND_ARG_PTR, .ptr_direction = LIND_PTR_INOUT,
+          .size_kind = LIND_SIZE_CONST, .const_size = sizeof(struct toy_stream),
+          .layout = &_stream_layout },
+    },
+    .ret = { .kind = LIND_RET_SCALAR },
+};
+
+// Mirrors struct toy_stream's wasm32 layout (all pointers are uint32_t) so
+// the handler can read/write next_out's raw shadow-pointer field directly.
+struct toy_stream_wasm32 { uint32_t next_in; uint32_t avail_in; uint32_t next_out; uint32_t avail_out; };
+
+// Mode table (_next_out_fspec DOES set ALLOW_ONE_PAST -- a fully-filled
+// cursor-advance buffer is the normal outcome):
+//   0 interior, unchanged (offset 0)     1 one-past (offset avail_out)
+//   2 null (no output written)           3 before-base
+//   4 after-end (offset avail_out+1)     5 huge delta
+//   6 unrelated object
+static uint64_t handler_stream_process(uint64_t s_u64, uint64_t a1, uint64_t a2,
+                                        uint64_t a3, uint64_t a4, uint64_t a5) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    struct toy_stream_wasm32 *s = (struct toy_stream_wasm32 *)LIND_AS_PTR(s_u64);
+    uint32_t mode = s->avail_in;  // avail_in is otherwise unused here -- repurposed as mode
+    printf("[Grate|provenance] toy_stream_process handler ran, mode=%u\n", mode);
+    fflush(stdout);
+    uint8_t *base = (uint8_t *)(uintptr_t)s->next_out;  // == this field's own shadow_start
+    uint32_t avail_out = s->avail_out;
+    uint8_t *val;
+    switch (mode) {
+        case 0: val = base; break;                            // interior, unchanged
+        case 1: val = base + avail_out; break;                  // one-past
+        case 2: val = 0; break;                                 // null (no output)
+        case 3: val = base - 1; break;                          // before-base
+        case 4: val = base + avail_out + 1; break;               // after-end
+        case 5: val = base + 0x40000000u; break;                 // huge delta
+        case 6: { static uint8_t u[8]; val = u; break; }         // unrelated object
+        default: val = base;
+    }
+    s->next_out = (uint32_t)(uintptr_t)val;
+    return 0;
+}
+LIND_DEFINE_MARSHAL_HANDLER(toy_stream_process, &stream_process_spec, handler_stream_process)
+
+// ---------------------------------------------------------------------------
+// Standard grate dispatcher — required export in every grate.
+// ---------------------------------------------------------------------------
+int64_t pass_fptr_to_wt(uint64_t fn_ptr_uint, uint64_t cageid,
+                    uint64_t arg1, uint64_t arg1cage,
+                    uint64_t arg2, uint64_t arg2cage,
+                    uint64_t arg3, uint64_t arg3cage,
+                    uint64_t arg4, uint64_t arg4cage,
+                    uint64_t arg5, uint64_t arg5cage,
+                    uint64_t arg6, uint64_t arg6cage) {
+    if (fn_ptr_uint == 0) {
+        fprintf(stderr, "[Grate|provenance] invalid fn ptr\n");
+        assert(0);
+    }
+    int64_t (*fn)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+              uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+              uint64_t, uint64_t, uint64_t) =
+        (int64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                 uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                 uint64_t, uint64_t, uint64_t))(uintptr_t)fn_ptr_uint;
+    return fn(cageid, arg1, arg1cage, arg2, arg2cage,
+              arg3, arg3cage, arg4, arg4cage,
+              arg5, arg5cage, arg6, arg6cage);
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) { fprintf(stderr, "Usage: %s <cage>\n", argv[0]); assert(0); }
+    int grateid = getpid();
+    pid_t pid = fork();
+    if (pid < 0) { perror("fork"); assert(0); }
+    if (pid == 0) {
+        int cageid = getpid();
+        int ret;
+        ret = register_lib_handler(cageid, "env", "toy_scan_buf", grateid, (uint64_t)(uintptr_t)&lind_mh_toy_scan_buf);
+        if (ret != 0) { fprintf(stderr, "[Grate|provenance] register toy_scan_buf failed\n"); assert(0); }
+        ret = register_lib_handler(cageid, "env", "toy_strtol_like", grateid, (uint64_t)(uintptr_t)&lind_mh_toy_strtol_like);
+        if (ret != 0) { fprintf(stderr, "[Grate|provenance] register toy_strtol_like failed\n"); assert(0); }
+        ret = register_lib_handler(cageid, "env", "toy_stream_process", grateid, (uint64_t)(uintptr_t)&lind_mh_toy_stream_process);
+        if (ret != 0) { fprintf(stderr, "[Grate|provenance] register toy_stream_process failed\n"); assert(0); }
+
+        printf("[Grate|provenance] registered 3/3 handlers\n");
+        fflush(stdout);
+        if (execv(argv[1], &argv[1]) == -1) { perror("execv"); assert(0); }
+    }
+    int status;
+    while (wait(&status) > 0) {}
+    int ce = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    fprintf(stderr, "[Grate|provenance] app exited %d\n", ce);
+    return 0;
+}

--- a/tests/grate-tests/lib-interpose/lind_marshal.h
+++ b/tests/grate-tests/lib-interpose/lind_marshal.h
@@ -160,13 +160,31 @@ struct lind_arg_spec {
     // pointer from grate-shadow offset to the source cage's buffer.
     // 1-based so the designated-init default (0) means "not applicable".
     uint32_t                out_ptr_into_arg1;
+    // Bitmask -- see LIND_ARGSPEC_ALLOW_ONE_PAST. Zero-initializes to "no
+    // flags set" under designated init, so an unset spec gets the strict
+    // (one-past rejected) default.
     uint32_t                flags;
 };
+
+// A callee-written pointer landing exactly at base+len ("one-past-the-end",
+// a valid pointer VALUE per C semantics even though it can't be
+// dereferenced) is the normal, expected outcome for some APIs -- a
+// cursor-advance OUT buffer that ends up completely filled (zlib's
+// next_out) -- but meaningless or never legitimately reachable for others
+// (a memchr-style scan, whose one-past result would be the byte just past
+// the searched region, never a matched byte). Whether one-past is even
+// possible depends entirely on the specific pointer relationship the spec
+// describes, so it is never assumed: a field/arg/return spec must opt in
+// explicitly via this flag, or a genuinely-one-past value from the callee
+// is rejected as being outside its shadow the same as anything else out of
+// range.
+#define LIND_ARGSPEC_ALLOW_ONE_PAST 0x1u
 
 struct lind_return_spec {
     enum lind_return_kind kind;
     uint32_t              alias_arg_index;  // PTR_ALIAS_ARG / PTR_INTO_ARG / HANDLE
     uint32_t              handle_class;     // RET_HANDLE: class for new handle registration
+    uint32_t               flags;           // LIND_ARGSPEC_ALLOW_ONE_PAST (PTR_INTO_ARG only)
 };
 
 struct lind_marshal_spec {
@@ -262,6 +280,103 @@ static inline void _lind_copy_or_abort(
     if (ret == LIND_API_ABORTED) {
         _lind_marshal_abort("copy_data_between_cages failed");
     }
+}
+
+// ---------------------------------------------------------------------------
+// Shadow pointer provenance (post-call: validating what the interposed
+// library wrote or returned)
+//
+// Every OUT-direction shadow buffer this dispatch call creates is owned by
+// it alone; the ONLY legitimate values a callee may leave behind in a
+// pointer-typed shadow field, or return through a LIND_RET_PTR_INTO_ARG
+// return, are addresses within that specific allocation -- from `base`
+// (the interior) up to and including `base + len` (one-past-the-end, valid
+// as a pointer VALUE per C semantics even though it can't be dereferenced).
+// A buggy or adversarial library returning anything else -- an address
+// before base, past one-past-the-end, or belonging to a different shadow
+// entirely -- must never be translated and hand back a fabricated or
+// out-of-bounds source-cage address; every call site below fails closed via
+// _lind_marshal_abort instead.
+// ---------------------------------------------------------------------------
+
+// Validates that `candidate` lies within [base, base+len) of a shadow
+// allocation -- or, if `allow_one_past` is set, within [base, base+len]
+// (see LIND_ARGSPEC_ALLOW_ONE_PAST's doc). Guards the base+len computation
+// itself against overflow (a real allocation's bounds can never wrap the
+// address space, so an overflow here means `base`/`len` themselves are
+// bogus). Returns 1 and sets *out_offset on success; returns 0 without
+// touching *out_offset otherwise.
+static inline int _lind_validate_shadow_offset(uintptr_t base, size_t len,
+                                                uintptr_t candidate,
+                                                int allow_one_past,
+                                                uint64_t *out_offset)
+{
+    if (len > (size_t)-1 - base)
+        return 0;
+    uintptr_t end = base + len;
+    if (candidate < base) return 0;
+    if (candidate == end) {
+        if (!allow_one_past) return 0;
+    } else if (candidate > end) {
+        return 0;
+    }
+    *out_offset = (uint64_t)(candidate - base);
+    return 1;
+}
+
+// Every wasm32 address (this port's only target) fits in 32 bits; both a
+// candidate pointer VALUE from the callee and a source-cage address this
+// module itself computed must fit before either takes part in pointer
+// arithmetic. Skipping this and narrowing straight to uintptr_t (32-bit
+// here) would let a fabricated 64-bit candidate with high bits set alias
+// into a valid shadow range purely by truncation, and would let a bogus
+// source_ptr make an overflow check that subtracts it from UINT32_MAX wrap
+// instead of catching it.
+static inline void _lind_check_fits_wasm32_addr(uint64_t v, const char *reason) {
+    if (v > (uint64_t)UINT32_MAX)
+        _lind_marshal_abort(reason);
+}
+
+// Every shadow allocation belongs to exactly the (source_cage, grate_cage)
+// pair this dispatch call was invoked with -- the arena is reset at the top
+// of every lind_marshal_dispatch call (_lind_marshal_reset), so today this
+// can only ever fail if a record were somehow read across two different
+// dispatch calls. Checked anyway, unconditionally, at every site that
+// trusts a shadow/ptr_field_track record: the record itself carries no
+// other proof of which call created it, and that stops being a paper
+// guarantee the moment any future change relaxes the per-call arena reset
+// (e.g. concurrent dispatch, or shadows outliving a single call).
+static inline void _lind_check_shadow_owner(uint64_t rec_source_cage,
+                                             uint64_t rec_grate_cage,
+                                             uint64_t source_cage,
+                                             uint64_t grate_cage,
+                                             const char *reason)
+{
+    if (rec_source_cage != source_cage || rec_grate_cage != grate_cage)
+        _lind_marshal_abort(reason);
+}
+
+// Translates a grate-shadow pointer VALUE the callee wrote or returned into
+// its equivalent source-cage address, aborting if it doesn't resolve to a
+// valid position within the given shadow allocation. NULL is a legitimate
+// value at every call site this is used from (e.g. strtol's endptr when no
+// conversion happened, or a "not found" return) and always passes through
+// unchanged, bypassing provenance validation entirely -- there is no shadow
+// offset to compute for it.
+static inline uint64_t _lind_translate_shadow_ptr_or_abort(
+    uintptr_t base, size_t len, int allow_one_past, uint64_t source_ptr,
+    uint64_t candidate, const char *reason)
+{
+    if (candidate == 0)
+        return 0;
+    _lind_check_fits_wasm32_addr(candidate, reason);
+    _lind_check_fits_wasm32_addr(source_ptr, reason);
+    uint64_t offset;
+    if (!_lind_validate_shadow_offset(base, len, (uintptr_t)candidate, allow_one_past, &offset))
+        _lind_marshal_abort(reason);
+    if (offset > (uint64_t)UINT32_MAX - source_ptr)
+        _lind_marshal_abort("translated pointer overflows the source cage's address space");
+    return source_ptr + offset;
 }
 
 // ---------------------------------------------------------------------------
@@ -361,6 +476,12 @@ struct _lind_ptr_field_track {
     uint32_t  offset;           // byte offset of this field within the parent struct
     uint64_t  orig_src_ptr;     // original source-cage ptr stored in this field
     uint8_t  *shadow_start;     // start of the child shadow buffer
+    size_t    shadow_len;       // allocated length of the child shadow buffer --
+                                 // the only trustworthy bound on how far the
+                                 // callee may legitimately advance a pointer
+                                 // into it (see _lind_validate_shadow_offset)
+    uint64_t  source_cage;      // cages this allocation belongs to -- see
+    uint64_t  grate_cage;       // _lind_check_shadow_owner's doc
     const struct lind_arg_spec *spec;  // field spec (for recursive post-call)
 };
 
@@ -370,6 +491,8 @@ struct _lind_shadow {
     void                  *shadow_ptr;
     size_t                 size;
     enum lind_ptr_direction direction;
+    uint64_t                source_cage;  // cages this allocation belongs to
+    uint64_t                grate_cage;   // -- see _lind_check_shadow_owner
     // Nested struct support (NULL layout = flat buffer):
     const struct lind_layout      *layout;
     struct _lind_ptr_field_track  *ptr_fields;
@@ -628,6 +751,9 @@ static void *_lind_pre_ptr(uint64_t src_ptr, const struct lind_arg_spec *as,
                     ptf[n].offset        = field->offset;
                     ptf[n].orig_src_ptr  = child_src;
                     ptf[n].shadow_start  = (uint8_t *)child_shadow;
+                    ptf[n].shadow_len    = child_size;
+                    ptf[n].source_cage   = source_cage;
+                    ptf[n].grate_cage    = grate_cage;
                     ptf[n].spec          = fspec;
                     n++;
                 }
@@ -691,82 +817,132 @@ static void _lind_post_struct(const struct _lind_shadow *s,
 {
     if (s->direction != LIND_PTR_OUT && s->direction != LIND_PTR_INOUT)
         return;
+    _lind_check_shadow_owner(s->source_cage, s->grate_cage, source_cage, grate_cage,
+                              "struct shadow does not belong to this call's cages");
 
     const struct lind_layout *lo = s->layout;
+    uint32_t nptf = s->n_ptr_fields;
 
-    // Step 1: copy the child pointer data back to source cage, then fix up ptr fields.
-    for (uint32_t p = 0; p < s->n_ptr_fields; p++) {
+    // Phase 1 (validate + compute only -- no writes to the source cage
+    // yet): for every tracked pointer field, confirm its shadow ownership
+    // and the position the callee left it at, then compute both its
+    // copy-back size and its translated source-cage value into scratch
+    // memory. A callee that corrupts one field must never be able to leak
+    // another field's -- or its own -- raw grate pointer into caller memory
+    // before the abort catches it, so nothing is written to the source
+    // cage until every field here has validated.
+    size_t   *copy_back_size = NULL;
+    uint32_t *new_src        = NULL;
+    if (nptf > 0) {
+        if (nptf > (size_t)-1 / sizeof(size_t) || nptf > (size_t)-1 / sizeof(uint32_t))
+            _lind_marshal_abort("pointer-field post-validation count overflow");
+        copy_back_size = (size_t *)_lind_marshal_alloc(nptf * sizeof(size_t));
+        new_src        = (uint32_t *)_lind_marshal_alloc(nptf * sizeof(uint32_t));
+        if (!copy_back_size || !new_src)
+            _lind_marshal_abort("post-call field validation arena exhausted");
+    }
+
+    for (uint32_t p = 0; p < nptf; p++) {
         const struct _lind_ptr_field_track *ptf = &s->ptr_fields[p];
+        _lind_check_shadow_owner(ptf->source_cage, ptf->grate_cage, source_cage, grate_cage,
+                                  "struct field shadow does not belong to this call's cages");
+
+        // cur_shadow_u32 is whatever the callee left in this field --
+        // entirely untrusted. 0 is a legitimate "no output here" value
+        // (e.g. an optional nested out-pointer the library chose not to
+        // fill) and passes straight through with no copy-back and no
+        // provenance check; anything else must land within this field's
+        // own shadow allocation (up to one-past-the-end only if the field's
+        // spec opts into LIND_ARGSPEC_ALLOW_ONE_PAST).
+        uint32_t cur_shadow_u32 =
+            *(uint32_t *)((uint8_t *)s->shadow_ptr + ptf->offset);
+        if (cur_shadow_u32 == 0) {
+            copy_back_size[p] = 0;
+            new_src[p] = 0;
+            continue;
+        }
+
+        int allow_one_past = (ptf->spec->flags & LIND_ARGSPEC_ALLOW_ONE_PAST) != 0;
+        uint64_t adv_offset;
+        if (!_lind_validate_shadow_offset((uintptr_t)ptf->shadow_start,
+                                           ptf->shadow_len,
+                                           (uintptr_t)cur_shadow_u32,
+                                           allow_one_past,
+                                           &adv_offset))
+            _lind_marshal_abort("struct field: OUT pointer left outside its own shadow buffer");
+
+        // How many bytes to copy back: from shadow_start up to wherever the
+        // handler left the pointer (may be advanced for INOUT/cursor
+        // buffers, e.g. zlib's next_out). Only meaningful for OUT/INOUT
+        // fields -- an IN-only field's data was never meant to be written
+        // back, though its pointer is still translated below like any
+        // other tracked field.
+        size_t cbsize = 0;
         if (ptf->spec->ptr_direction == LIND_PTR_OUT ||
             ptf->spec->ptr_direction == LIND_PTR_INOUT) {
+            cbsize = (size_t)adv_offset;
 
-            // Determine the size to copy back.
-            // Read current shadow ptr from the struct shadow at this field's offset.
-            uint32_t cur_shadow_u32 =
-                *(uint32_t *)((uint8_t *)s->shadow_ptr + ptf->offset);
-            uint8_t *cur_shadow_ptr = (uint8_t *)(uintptr_t)cur_shadow_u32;
-
-            // How many bytes to copy: from original shadow_start up to wherever
-            // the handler left the pointer (may be advanced for INOUT buffers).
-            size_t copy_back_size;
-            if (cur_shadow_ptr >= ptf->shadow_start) {
-                copy_back_size = (size_t)(cur_shadow_ptr - ptf->shadow_start);
-            } else {
-                copy_back_size = 0;
-            }
-
-            // Always copy at least the originally-allocated child buffer data back.
-            // Use the field's size if we can infer it.
-            if (copy_back_size == 0 && lo != NULL) {
-                // Find the sibling size field if available.
+            // Unchanged pointer: fall back to the field's nominal size
+            // instead of copying back zero bytes. That size may itself
+            // come from a sibling field the callee could also have
+            // modified during the call (e.g. reporting a bogus "bytes
+            // written" count without ever advancing the pointer) -- clamp
+            // to the buffer's actual allocated length so a stationary
+            // pointer can never trigger an oversized copy either,
+            // regardless of what the callee claims.
+            if (cbsize == 0 && lo != NULL) {
                 const struct lind_field *fld = NULL;
                 for (uint32_t f = 0; f < lo->nfields; f++) {
                     if (lo->fields[f].offset == ptf->offset) { fld = &lo->fields[f]; break; }
                 }
                 if (fld && ptf->spec->size_kind == LIND_SIZE_FROM_ARG) {
                     uint32_t sib_off = lo->fields[ptf->spec->size_arg_index].offset;
-                    copy_back_size = (size_t)(*(uint32_t *)((uint8_t *)s->shadow_ptr + sib_off));
+                    cbsize = (size_t)(*(uint32_t *)((uint8_t *)s->shadow_ptr + sib_off));
                 } else if (ptf->spec->size_kind == LIND_SIZE_CONST) {
-                    copy_back_size = (size_t)ptf->spec->const_size;
+                    cbsize = (size_t)ptf->spec->const_size;
                 }
-            }
-
-            if (copy_back_size > 0) {
-                _lind_copy_or_abort(grate_cage, source_cage,
-                    (uint64_t)(uintptr_t)ptf->shadow_start, grate_cage,
-                    ptf->orig_src_ptr, source_cage,
-                    (uint64_t)copy_back_size, 0);
+                if (cbsize > ptf->shadow_len)
+                    cbsize = ptf->shadow_len;
             }
         }
+        copy_back_size[p] = cbsize;
+
+        _lind_check_fits_wasm32_addr(ptf->orig_src_ptr,
+            "struct field: source pointer overflows the source cage's address space");
+        if (adv_offset > (uint64_t)UINT32_MAX - ptf->orig_src_ptr)
+            _lind_marshal_abort("struct field: translated pointer overflows the source cage's address space");
+        new_src[p] = (uint32_t)(ptf->orig_src_ptr + adv_offset);
     }
 
-    // Step 2: copy the whole struct shadow back to source (writes scalar fields +
-    //         whatever ptr values the handler left).
+    // Phase 2 (still no cage writes): sanitize the struct shadow IN
+    // GRATE-LOCAL MEMORY, replacing each tracked pointer field's raw grate
+    // address with its already-validated, translated source-cage
+    // equivalent. Only this dispatch call's own shadow buffer is touched.
+    for (uint32_t p = 0; p < nptf; p++) {
+        const struct _lind_ptr_field_track *ptf = &s->ptr_fields[p];
+        *(uint32_t *)((uint8_t *)s->shadow_ptr + ptf->offset) = new_src[p];
+    }
+
+    // Phase 3: every field has validated and the struct shadow now holds
+    // only sanitized pointer values, so it's finally safe to write to the
+    // source cage -- each child buffer's data, then the whole struct in a
+    // single copy (which also carries the sanitized pointers and any plain
+    // scalar fields the handler updated). No raw grate pointer is ever
+    // written to caller memory at any point in this function.
+    for (uint32_t p = 0; p < nptf; p++) {
+        const struct _lind_ptr_field_track *ptf = &s->ptr_fields[p];
+        if (copy_back_size[p] > 0) {
+            _lind_copy_or_abort(grate_cage, source_cage,
+                (uint64_t)(uintptr_t)ptf->shadow_start, grate_cage,
+                ptf->orig_src_ptr, source_cage,
+                (uint64_t)copy_back_size[p], 0);
+        }
+    }
     if (s->size > 0) {
         _lind_copy_or_abort(grate_cage, source_cage,
             (uint64_t)(uintptr_t)s->shadow_ptr, grate_cage,
             s->source_ptr, source_cage,
             (uint64_t)s->size, 0);
-    }
-
-    // Step 3: fix up ptr fields — overwrite with source-cage addresses, not shadow addrs.
-    for (uint32_t p = 0; p < s->n_ptr_fields; p++) {
-        const struct _lind_ptr_field_track *ptf = &s->ptr_fields[p];
-
-        // Compute delta = how far the handler advanced the ptr.
-        uint32_t cur_shadow_u32 =
-            *(uint32_t *)((uint8_t *)s->shadow_ptr + ptf->offset);
-        uint8_t *cur_shadow_ptr = (uint8_t *)(uintptr_t)cur_shadow_u32;
-        int64_t delta = (int64_t)(cur_shadow_ptr - ptf->shadow_start);
-
-        // New source-cage ptr = original + delta.
-        uint32_t new_src_u32 = (uint32_t)(int32_t)
-            ((int64_t)(int32_t)(uint32_t)ptf->orig_src_ptr + delta);
-
-        _lind_copy_or_abort(grate_cage, source_cage,
-            (uint64_t)(uintptr_t)&new_src_u32, grate_cage,
-            s->source_ptr + ptf->offset, source_cage,
-            sizeof(uint32_t), 0);
     }
 }
 
@@ -870,6 +1046,8 @@ static inline uint64_t lind_marshal_dispatch(
                     shadows[nshadows].shadow_ptr   = shadow;
                     shadows[nshadows].size         = shadow_size;
                     shadows[nshadows].direction    = as->ptr_direction;
+                    shadows[nshadows].source_cage  = source_cage;
+                    shadows[nshadows].grate_cage   = grate_cage;
                     shadows[nshadows].layout       = as->layout;
                     shadows[nshadows].ptr_fields   = ptf;
                     shadows[nshadows].n_ptr_fields = n_ptf;
@@ -894,24 +1072,33 @@ static inline uint64_t lind_marshal_dispatch(
         const struct lind_arg_spec *sas = &spec->args[shadows[s].arg_index];
 
         // OUT pointer-to-pointer that aliases an arg (strtol's char** endptr):
-        // the callee wrote a pointer into arg[target]'s buffer; translate it from
-        // the grate shadow to the source cage and write it back to the outer slot.
+        // the callee wrote a pointer into arg[target]'s buffer; translate it
+        // from the grate shadow to the source cage and write it back to the
+        // outer slot. `inner` is entirely callee-controlled -- never expose
+        // it, or an address derived from it, to the source cage without
+        // confirming it's a valid position within the aliased argument's own
+        // shadow allocation; fail closed otherwise (an out-of-bounds value
+        // here is either a library bug or a deliberate attempt to leak a
+        // grate-process address to the source cage).
         if (sas->out_ptr_into_arg1 != 0) {
             uint32_t target = sas->out_ptr_into_arg1 - 1;
             uint32_t inner = *(uint32_t *)shadows[s].shadow_ptr;  // what the callee wrote
-            uint32_t translated = inner;                          // default: pass through (e.g. NULL)
+            uint32_t translated = 0;                              // default: NULL
             if (inner != 0) {
+                const struct _lind_shadow *tshadow = NULL;
                 for (uint32_t t = 0; t < nshadows; t++) {
-                    if (shadows[t].arg_index == target) {
-                        uintptr_t base = (uintptr_t)shadows[t].shadow_ptr;
-                        if ((uintptr_t)inner >= base &&
-                            (uintptr_t)inner <= base + shadows[t].size) {
-                            uint64_t off = (uintptr_t)inner - base;
-                            translated = (uint32_t)((uint32_t)shadows[t].source_ptr + off);
-                        }
-                        break;
-                    }
+                    if (shadows[t].arg_index == target) { tshadow = &shadows[t]; break; }
                 }
+                if (!tshadow)
+                    _lind_marshal_abort("OUT ptr-to-ptr: aliased argument has no shadow");
+                _lind_check_shadow_owner(tshadow->source_cage, tshadow->grate_cage,
+                                          source_cage, grate_cage,
+                                          "OUT ptr-to-ptr: aliased shadow does not belong to this call's cages");
+                translated = (uint32_t)_lind_translate_shadow_ptr_or_abort(
+                    (uintptr_t)tshadow->shadow_ptr, tshadow->size,
+                    (sas->flags & LIND_ARGSPEC_ALLOW_ONE_PAST) != 0,
+                    tshadow->source_ptr, (uint64_t)inner,
+                    "OUT ptr-to-ptr: value outside the aliased argument's shadow buffer");
             }
             _lind_copy_or_abort(grate_cage, source_cage,
                 (uint64_t)(uintptr_t)&translated, grate_cage,
@@ -943,23 +1130,31 @@ static inline uint64_t lind_marshal_dispatch(
             break;
 
         case LIND_RET_PTR_INTO_ARG: {
-            // handler_ret is a pointer into a shadow buffer.
-            // Translate: result = source_ptr + (handler_ret - shadow_ptr).
+            // handler_ret is a pointer into a shadow buffer -- entirely
+            // callee-controlled. Translate it to the source cage's
+            // equivalent address only once confirmed to lie within the
+            // aliased argument's own shadow allocation; never fall back to
+            // exposing the raw handler_ret (a grate-process address) to the
+            // source cage.
             uint32_t idx = spec->ret.alias_arg_index;
             if (handler_ret == 0) {
                 result = 0;  // NULL return (not found)
                 break;
             }
+            const struct _lind_shadow *rshadow = NULL;
             for (uint32_t s = 0; s < nshadows; s++) {
-                if (shadows[s].arg_index == idx) {
-                    int64_t off = (int64_t)handler_ret
-                                - (int64_t)(uintptr_t)shadows[s].shadow_ptr;
-                    result = (uint64_t)((int64_t)(int32_t)(uint32_t)shadows[s].source_ptr
-                                       + off);
-                    goto done;
-                }
+                if (shadows[s].arg_index == idx) { rshadow = &shadows[s]; break; }
             }
-            result = handler_ret;  // fallback
+            if (!rshadow)
+                _lind_marshal_abort("pointer-into-arg return: aliased argument has no shadow");
+            _lind_check_shadow_owner(rshadow->source_cage, rshadow->grate_cage,
+                                      source_cage, grate_cage,
+                                      "pointer-into-arg return: aliased shadow does not belong to this call's cages");
+            result = _lind_translate_shadow_ptr_or_abort(
+                (uintptr_t)rshadow->shadow_ptr, rshadow->size,
+                (spec->ret.flags & LIND_ARGSPEC_ALLOW_ONE_PAST) != 0,
+                rshadow->source_ptr, handler_ret,
+                "pointer-into-arg return: value outside the aliased argument's shadow buffer");
             break;
         }
 
@@ -977,7 +1172,6 @@ static inline uint64_t lind_marshal_dispatch(
             result = handler_ret;
             break;
     }
-done:
     _lind_marshal_reset();
     return result;
 }

--- a/tests/grate-tests/lib-interpose/run_tests.sh
+++ b/tests/grate-tests/lib-interpose/run_tests.sh
@@ -620,6 +620,65 @@ run_test "fail-closed-widesig" \
     -- "    1: lib-3i portal: env.toy_wide_sum7 has 7 raw ABI argument slots, exceeding the interposition transport's 6-slot capacity" \
     -- "[Cage|widesig] FAIL: call returned normally" "[Grate|widesig] toy_wide_sum7 handler ran (should not happen)"
 
+# fail-closed-provenance-*: post-call pointer-provenance validation (issue
+# #7). provenance_grate.c's three handlers deliberately fabricate the values
+# a buggy or adversarial interposed library might leave behind -- before the
+# shadow's base, past its one-past-the-end, wildly out of range, and
+# pointing at a real but unrelated grate address -- across the three
+# post-call translation paths (LIND_RET_PTR_INTO_ARG, out_ptr_into_arg1, and
+# struct-field OUT/cursor copy-back+fixup). Each target loops over every one
+# of its modes in a single cage invocation and reports one aggregate PASS
+# line; a _lind_marshal_abort trap only fails the one call it's in (see
+# threei::GRATE_ERR's doc), so invalid modes don't stop the cage from
+# reaching its later, valid ones. The per-mode "handler ran" lines are
+# evidence every mode actually executed, not skipped.
+GRATE_EXTRA=("$SCRIPT_DIR/custom-lib/libtoy.c")
+run_test "fail-closed-provenance-scan" \
+    "fail-closed/provenance_cage.c" \
+    "fail-closed/provenance_grate.c" \
+    "env=/lib/libtoy.so" "yes" \
+    "/provenance_cage.cwasm" "scan" \
+    -- "[Grate|provenance] registered 3/3 handlers" "[Cage|provenance] PASS: scan (all 8 modes)" \
+    -- "[Grate|provenance] toy_scan_buf handler ran, mode=0" \
+       "[Grate|provenance] toy_scan_buf handler ran, mode=1" \
+       "[Grate|provenance] toy_scan_buf handler ran, mode=2" \
+       "[Grate|provenance] toy_scan_buf handler ran, mode=3" \
+       "[Grate|provenance] toy_scan_buf handler ran, mode=4" \
+       "[Grate|provenance] toy_scan_buf handler ran, mode=5" \
+       "[Grate|provenance] toy_scan_buf handler ran, mode=6" \
+       "[Grate|provenance] toy_scan_buf handler ran, mode=7"
+
+GRATE_EXTRA=("$SCRIPT_DIR/custom-lib/libtoy.c")
+run_test "fail-closed-provenance-strtol" \
+    "fail-closed/provenance_cage.c" \
+    "fail-closed/provenance_grate.c" \
+    "env=/lib/libtoy.so" "yes" \
+    "/provenance_cage.cwasm" "strtol" \
+    -- "[Grate|provenance] registered 3/3 handlers" "[Cage|provenance] PASS: strtol (all 8 modes)" \
+    -- "[Grate|provenance] toy_strtol_like handler ran, mode='0'" \
+       "[Grate|provenance] toy_strtol_like handler ran, mode='1'" \
+       "[Grate|provenance] toy_strtol_like handler ran, mode='2'" \
+       "[Grate|provenance] toy_strtol_like handler ran, mode='3'" \
+       "[Grate|provenance] toy_strtol_like handler ran, mode='4'" \
+       "[Grate|provenance] toy_strtol_like handler ran, mode='5'" \
+       "[Grate|provenance] toy_strtol_like handler ran, mode='6'" \
+       "[Grate|provenance] toy_strtol_like handler ran, mode='7'"
+
+GRATE_EXTRA=("$SCRIPT_DIR/custom-lib/libtoy.c")
+run_test "fail-closed-provenance-stream" \
+    "fail-closed/provenance_cage.c" \
+    "fail-closed/provenance_grate.c" \
+    "env=/lib/libtoy.so" "yes" \
+    "/provenance_cage.cwasm" "stream" \
+    -- "[Grate|provenance] registered 3/3 handlers" "[Cage|provenance] PASS: stream (all 7 modes)" \
+    -- "[Grate|provenance] toy_stream_process handler ran, mode=0" \
+       "[Grate|provenance] toy_stream_process handler ran, mode=1" \
+       "[Grate|provenance] toy_stream_process handler ran, mode=2" \
+       "[Grate|provenance] toy_stream_process handler ran, mode=3" \
+       "[Grate|provenance] toy_stream_process handler ran, mode=4" \
+       "[Grate|provenance] toy_stream_process handler ran, mode=5" \
+       "[Grate|provenance] toy_stream_process handler ran, mode=6"
+
 DECLARED_TESTS+=("fail-closed")
 
 # --------------------------------------------------------------------------

--- a/tests/grate-tests/lib-interpose/zlib-python/zlib-python_grate.c
+++ b/tests/grate-tests/lib-interpose/zlib-python/zlib-python_grate.c
@@ -76,6 +76,10 @@ static struct lind_arg_spec _next_out_fspec = {
     .ptr_direction  = LIND_PTR_OUT,
     .size_kind      = LIND_SIZE_FROM_ARG,
     .size_arg_index = 4,   // sibling field index 4 = avail_out
+    // A completely filled output buffer is the normal outcome, not an edge
+    // case: next_out legitimately ends up one-past-the-end of the shadow
+    // whenever the handler writes exactly avail_out bytes.
+    .flags          = LIND_ARGSPEC_ALLOW_ONE_PAST,
 };
 
 static struct lind_field _zstream_fields[6] = {


### PR DESCRIPTION
## Summary

- validate pointers returned or written by interposed libraries against the specific shadow allocation they may reference
- reject before-base, after-end, unrelated, oversized, and non-wasm32 pointer values before translation
- record shadow lengths and cage ownership and use checked source-address arithmetic
- make one-past results an explicit marshal-spec capability instead of accepting them globally
- validate and sanitize every nested pointer field before writing any struct data back to the caller
- add strict end-to-end tests for pointer returns, pointer-to-pointer outputs, and zlib-style cursor fields

## Verification

- `make format`
- harness self-tests: 19 passed, 0 failed
- focused suite: 34 passed, 0 failed, 0 skipped
- `bash -n tests/grate-tests/lib-interpose/run_tests.sh`
- `git diff --check`

Closes #7.

Future generated grates for cursor-style APIs must derive the one-past capability from sound semantic metadata rather than a handwritten symbol list.
