### PR TITLE
Reject unsupported library portal signatures

### DIFF
--- a/src/wasmtime/Cargo.toml
+++ b/src/wasmtime/Cargo.toml
@@ -205,6 +205,7 @@ members = [
   "crates/cage",
   "crates/lind-3i",
   "crates/lind-remote-lib",
+  "crates/lib3i-portal-signature-check",
 ]
 exclude = [
   'docs/rust_wasi_markdown_parser',

--- a/src/wasmtime/crates/lib3i-portal-signature-check/Cargo.toml
+++ b/src/wasmtime/crates/lib3i-portal-signature-check/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "lib3i-portal-signature-check"
+version = "0.1.0"
+edition = "2021"
+
+# Standalone, runnable regression check for the lib-3i portal's signature
+# validation (issue #13): unsupported wasm value types (v128, funcref,
+# externref) and multi-result signatures cannot be expressed by any C
+# source the Lind toolchain compiles, so this is a real, documented
+# capability gap -- see CLAUDE.md's toolchain-exception clause. This crate
+# uses raw WAT text (via wasmtime's `wat` feature) to construct the shapes
+# directly and exercises the real `Linker::instance_dylink` portal-install
+# code path, not a reimplementation of it. See src/main.rs's doc comment
+# for how to run it.
+[dependencies]
+wasmtime = { path = "../wasmtime", default-features = false, features = [
+    "cranelift", "pooling-allocator", "gc-null", "threads", "demangle",
+    "addr2line", "cache", "anyhow", "wat",
+] }
+threei = { path = "../threei" }

--- a/src/wasmtime/crates/lib3i-portal-signature-check/src/main.rs
+++ b/src/wasmtime/crates/lib3i-portal-signature-check/src/main.rs
@@ -1,0 +1,235 @@
+//! Runnable regression check for the lib-3i portal's install-time signature
+//! validation (issue #13). See this crate's Cargo.toml for why it exists as
+//! a standalone binary using raw WAT: v128, funcref/externref, and
+//! multi-result signatures cannot be produced by any C source the Lind
+//! toolchain compiles, so `tests/grate-tests/lib-interpose`'s C-based
+//! fail-closed suite structurally cannot reach these shapes.
+//!
+//! This exercises the REAL `Linker::instance_dylink` portal-install code
+//! path (the same one `wasmtime-lind-dylink`/lind-boot calls for every real
+//! cage), not a reimplementation of its logic -- only the surrounding cage
+//! bootstrap (a real running grate process for `dispatch_lib_call` to
+//! reach) is out of scope here, so "supported" cases are verified by
+//! confirming dispatch was genuinely attempted (see `run_case`'s doc)
+//! rather than by completing a full round trip through a real handler.
+//!
+//! Run: `cargo run -p lib3i-portal-signature-check`
+//! (from src/wasmtime/; needs no special feature flags of its own -- the
+//! `wat` feature this crate needs from `wasmtime` is pulled in by its own
+//! Cargo.toml, independent of lind-boot's normal, `wat`-free feature set)
+
+use wasmtime::error::Context;
+use wasmtime::{bail, ensure, Config, Engine, Instance, Linker, Module, Result, Store, Val, V128};
+
+// A handler cage id that intentionally does not exist. dispatch_lib_call's
+// first step (threei::with_cage) looks up this id and fails gracefully
+// (ESRCH) if there's no real cage -- so calling through a portal that
+// genuinely reached dispatch_lib_call returns an ordinary value (whatever
+// ESRCH encodes to), while a portal that rejected the signature up front
+// traps instead, with the "cannot be transported" message. That gap is
+// what each check below distinguishes: reaching dispatch at all (a normal
+// return, not a trap) is exactly the evidence that the real handler
+// function this fake handler_cage_id/fn_ptr stands in for was never (and,
+// for accepted signatures, would legitimately have been) entered.
+const FAKE_CALLER_CAGE_ID: u64 = 0x5151_0001;
+const FAKE_HANDLER_CAGE_ID: u64 = 0x5151_0002;
+const FAKE_FN_PTR: u64 = 0xDEAD_BEEF;
+
+const LIB_WAT: &str = r#"
+(module
+  (func (export "unsupported_v128_param") (param v128) (result i32)
+    i32.const 0)
+  (func (export "unsupported_v128_result") (param i32) (result v128)
+    v128.const i32x4 0 0 0 0)
+  (func (export "unsupported_funcref_param") (param funcref) (result i32)
+    i32.const 0)
+  (func (export "unsupported_funcref_result") (param i32) (result funcref)
+    ref.null func)
+  (func (export "unsupported_externref_param") (param externref) (result i32)
+    i32.const 0)
+  (func (export "unsupported_externref_result") (param i32) (result externref)
+    ref.null extern)
+  (func (export "multi_result") (param i32) (result i32 i32)
+    local.get 0
+    local.get 0)
+  (func (export "zero_result") (param i32)
+    nop)
+  (func (export "single_result") (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.add)
+)
+"#;
+
+struct Case {
+    symbol: &'static str,
+    args: Vec<Val>,
+    /// Some((reason substring, full formatted signature)) if this signature
+    /// must be rejected at install time -- the trap message must contain
+    /// both; None if it must be accepted (dispatch genuinely attempted).
+    must_reject: Option<(&'static str, &'static str)>,
+}
+
+fn main() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_simd(true);
+    config.wasm_reference_types(true);
+    let engine = Engine::new(&config).context("building engine")?;
+    let mut store = Store::new(&engine, ());
+
+    let lib_module = Module::new(&engine, LIB_WAT).context("parsing fixture WAT")?;
+    // Sanity-instantiate once against the throwaway store above, just to
+    // confirm the fixture module itself is well-formed before looping.
+    Instance::new(&mut store, &lib_module, &[]).context("instantiating fixture WAT")?;
+
+    let cases = [
+        Case {
+            symbol: "unsupported_v128_param",
+            args: vec![Val::V128(V128::from(0))],
+            must_reject: Some(("param 0 has type v128", "(v128) -> (i32)")),
+        },
+        Case {
+            symbol: "unsupported_v128_result",
+            args: vec![Val::I32(0)],
+            must_reject: Some(("result 0 has type v128", "(i32) -> (v128)")),
+        },
+        // funcref/externref are reference types, distinct from v128 (a
+        // vector type) -- reference-type handling can evolve independently
+        // (e.g. the GC proposal), so it's covered by its own cases rather
+        // than assumed to follow the same code path as v128.
+        Case {
+            symbol: "unsupported_funcref_param",
+            args: vec![Val::FuncRef(None)],
+            must_reject: Some((
+                "param 0 has type (ref null func)",
+                "((ref null func)) -> (i32)",
+            )),
+        },
+        Case {
+            symbol: "unsupported_funcref_result",
+            args: vec![Val::I32(0)],
+            must_reject: Some((
+                "result 0 has type (ref null func)",
+                "(i32) -> ((ref null func))",
+            )),
+        },
+        Case {
+            symbol: "unsupported_externref_param",
+            args: vec![Val::ExternRef(None)],
+            must_reject: Some((
+                "param 0 has type (ref null extern)",
+                "((ref null extern)) -> (i32)",
+            )),
+        },
+        Case {
+            symbol: "unsupported_externref_result",
+            args: vec![Val::I32(0)],
+            must_reject: Some((
+                "result 0 has type (ref null extern)",
+                "(i32) -> ((ref null extern))",
+            )),
+        },
+        Case {
+            symbol: "multi_result",
+            args: vec![Val::I32(0)],
+            must_reject: Some(("2 results, exceeding", "(i32) -> (i32, i32)")),
+        },
+        Case {
+            symbol: "zero_result",
+            args: vec![Val::I32(0)],
+            must_reject: None,
+        },
+        Case {
+            symbol: "single_result",
+            args: vec![Val::I32(1), Val::I32(2)],
+            must_reject: None,
+        },
+    ];
+
+    let mut fail = 0;
+    for case in &cases {
+        if let Err(e) = run_case(&engine, &lib_module, case) {
+            println!("FAIL  {}: {e:#}", case.symbol);
+            fail += 1;
+        } else {
+            println!("PASS  {}", case.symbol);
+        }
+    }
+
+    println!();
+    if fail == 0 {
+        println!("Results: {} passed, 0 failed", cases.len());
+        Ok(())
+    } else {
+        println!("Results: {} passed, {fail} failed", cases.len() - fail);
+        std::process::exit(1);
+    }
+}
+
+fn run_case(engine: &Engine, lib_module: &Module, case: &Case) -> Result<()> {
+    // Every real handler registration a grate performs goes through this
+    // exact entry point (threei::register_lib_handler wraps it for the
+    // syscall ABI; this is the plain-Rust core it calls into) -- so
+    // get_lib_handler, which Linker::instance_dylink's portal-install code
+    // queries, sees this the same way it would see a registration made by
+    // a real interposing grate.
+    threei::lib_handler_table::register_lib_handler_entry(
+        FAKE_CALLER_CAGE_ID,
+        "env",
+        case.symbol,
+        FAKE_HANDLER_CAGE_ID,
+        FAKE_FN_PTR,
+    );
+
+    let mut store = Store::new(engine, ());
+    let lib_instance =
+        Instance::new(&mut store, lib_module, &[]).context("instantiating fixture WAT")?;
+    let mut linker = Linker::<()>::new(engine);
+    linker
+        .instance_dylink(
+            &mut store,
+            "env",
+            lib_instance,
+            Some(FAKE_CALLER_CAGE_ID),
+            vec![],
+            None,
+            false,
+        )
+        .context("instance_dylink (portal install)")?;
+
+    let func = linker
+        .get(&mut store, "env", case.symbol)
+        .with_context(|| format!("{} was not linked as env.{}", case.symbol, case.symbol))?
+        .into_func()
+        .with_context(|| format!("env.{} did not link as a function", case.symbol))?;
+
+    let ty = func.ty(&store);
+    let mut results = vec![Val::I32(0); ty.results().len()];
+    let call_result = func.call(&mut store, &case.args, &mut results);
+
+    match (&case.must_reject, call_result) {
+        (Some((reason, signature)), Err(e)) => {
+            let msg = format!("{e:#}");
+            ensure!(
+                msg.contains("cannot be transported") && msg.contains(reason),
+                "expected a rejection containing {reason:?}, got: {msg}"
+            );
+            ensure!(
+                msg.contains(&format!("env.{}", case.symbol)),
+                "diagnostic missing symbol name: {msg}"
+            );
+            ensure!(
+                msg.contains(signature),
+                "diagnostic missing full signature {signature:?}: {msg}"
+            );
+            Ok(())
+        }
+        (Some((reason, _)), Ok(())) => {
+            bail!("expected rejection containing {reason:?}, but the call succeeded")
+        }
+        (None, Err(e)) => {
+            bail!("expected this supported signature to reach dispatch, but it was rejected: {e:#}")
+        }
+        (None, Ok(())) => Ok(()),
+    }
+}

--- a/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
@@ -258,6 +258,61 @@ pub(crate) enum DefinitionType {
 // fails the moment any of the four disagree.
 const LIND_MAX_RAW_ARG_SLOTS: usize = 6;
 
+// Renders a lowered signature as `(p0, p1, ...) -> (r0, r1, ...)`, e.g.
+// `(i32, v128, i64) -> (i32)`. Used to give every lib-3i portal rejection
+// diagnostic the complete shape being rejected -- the symbol name and a
+// single offending index alone don't distinguish overloaded-looking exports
+// or reveal a hidden ABI parameter (e.g. a synthetic sret pointer) sitting
+// earlier in the list.
+fn lib3i_format_signature(func_ty: &FuncType) -> String {
+    let params: Vec<String> = func_ty.params().map(|p| p.to_string()).collect();
+    let results: Vec<String> = func_ty.results().map(|r| r.to_string()).collect();
+    format!("({}) -> ({})", params.join(", "), results.join(", "))
+}
+
+// The lib-3i portal's transport carries only i32/i64/f32/f64 scalars, and
+// only ONE result -- dispatch_lib_call/pass_fptr_to_wt return a single i64,
+// with no channel for a second value, a v128 lane, or an opaque reference.
+// A signature outside that shape can't be installed as a real portal at
+// all: forwarding it would either silently zero an unsupported parameter
+// (a v128 or ref value has no meaningful representation in the transport's
+// raw u64 slots) or duplicate the single transported result across every
+// result slot of a multi-result function, handing the caller a value that
+// type-checks but is fabricated. Returns the reason the signature can't be
+// transported, or None if it's fully supported.
+fn lib3i_unsupported_signature_reason(func_ty: &FuncType) -> Option<String> {
+    if func_ty.params().len() > LIND_MAX_RAW_ARG_SLOTS {
+        return Some(format!(
+            "{} raw ABI argument slots, exceeding the interposition transport's \
+             {LIND_MAX_RAW_ARG_SLOTS}-slot capacity",
+            func_ty.params().len()
+        ));
+    }
+    for (i, p) in func_ty.params().enumerate() {
+        if !matches!(p, ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64) {
+            return Some(format!(
+                "param {i} has type {p}, which the transport cannot carry \
+                 (only i32/i64/f32/f64 scalars are supported)"
+            ));
+        }
+    }
+    if func_ty.results().len() > 1 {
+        return Some(format!(
+            "{} results, exceeding the interposition transport's single-result capacity",
+            func_ty.results().len()
+        ));
+    }
+    for (i, r) in func_ty.results().enumerate() {
+        if !matches!(r, ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64) {
+            return Some(format!(
+                "result {i} has type {r}, which the transport cannot carry \
+                 (only i32/i64/f32/f64 scalars are supported)"
+            ));
+        }
+    }
+    None
+}
+
 impl<T> Linker<T> {
     /// Creates a new [`Linker`].
     ///
@@ -1119,23 +1174,22 @@ impl<T> Linker<T> {
                         if let Some((handler_cage_id, fn_ptr)) = maybe_handler {
                             let func_ty = original_func.ty(&store);
 
-                            // See LIND_MAX_RAW_ARG_SLOTS: reject a wider
-                            // lowered signature outright instead of silently
-                            // truncating it via `.take(LIND_MAX_RAW_ARG_SLOTS)` below.
-                            if func_ty.params().len() > LIND_MAX_RAW_ARG_SLOTS {
+                            // Validate the whole lowered signature up front
+                            // -- argument count, argument types, result
+                            // count, and result types -- rather than
+                            // silently truncating/zeroing/duplicating data
+                            // the transport can't actually carry (see
+                            // lib3i_unsupported_signature_reason's doc).
+                            if let Some(reason) = lib3i_unsupported_signature_reason(&func_ty) {
                                 let symbol = format!("{module_name}.{name}");
-                                let nparams = func_ty.params().len();
-                                let portal = Func::new(
-                                    &mut store,
-                                    func_ty.clone(),
-                                    move |_, _, _| {
+                                let signature = lib3i_format_signature(&func_ty);
+                                let portal =
+                                    Func::new(&mut store, func_ty.clone(), move |_, _, _| {
                                         bail!(
-                                            "lib-3i portal: {symbol} has {nparams} raw ABI argument \
-                                         slots, exceeding the interposition transport's \
-                                         {LIND_MAX_RAW_ARG_SLOTS}-slot capacity"
+                                            "lib-3i portal: {symbol} {signature} cannot be \
+                                             transported: {reason}"
                                         );
-                                    },
-                                );
+                                    });
                                 self.insert(key, Definition::new(store.0, Extern::Func(portal)))?;
                                 continue;
                             }

--- a/tests/grate-tests/lib-interpose/run_tests.sh
+++ b/tests/grate-tests/lib-interpose/run_tests.sh
@@ -15,6 +15,13 @@
 # --allow-skips: without it, any skipped maintained test (e.g. a missing
 # fixture dependency) fails the run; pass it for an explicitly optional
 # local run.
+#
+# Unsupported wasm value types (v128, funcref/externref) and multi-result
+# signatures at lib-3i portal install time (issue #13) can't be reached from
+# any C source the Lind toolchain compiles, so that coverage lives in
+# src/wasmtime/crates/lib3i-portal-signature-check (raw WAT against the real
+# Linker::instance_dylink code path) and is run as a pre-flight step below,
+# alongside the raw-arg-slot consistency check.
 
 set -uo pipefail
 
@@ -235,6 +242,19 @@ $output"
 # before compiling anything, if those copies have drifted out of sync.
 if ! bash "$SCRIPT_DIR/check_raw_arg_slot_consistency.sh"; then
     echo "FATAL: raw-arg-slot constant consistency check failed (see above)" >&2
+    exit 1
+fi
+echo ""
+
+# Pre-flight: unsupported wasm value types (v128, funcref/externref) and
+# multi-result signatures at lib-3i portal install time (issue #13). No C
+# source compiles to those shapes, so this is a separate Rust crate built
+# on raw WAT -- see its own doc comment for why. Built fresh each run, same
+# reasoning as every cage/grate/fixture above: a stale local binary would
+# silently mask a real regression in linker.rs's portal-install validation.
+echo "Running lib3i-portal-signature-check (issue #13)..."
+if ! (cd "$REPO_ROOT/src/wasmtime" && cargo run --quiet -p lib3i-portal-signature-check); then
+    echo "FATAL: lib3i-portal-signature-check failed (see above)" >&2
     exit 1
 fi
 echo ""
@@ -617,7 +637,7 @@ run_test "fail-closed-widesig" \
     "env=/lib/libtoy.so" "yes" \
     "/widesig_cage.cwasm" \
     -- "[Grate|widesig] registered 1/1 handlers" "[Grate|widesig] PASS: rejected (cage crashed as expected, exit=1)" \
-    -- "    1: lib-3i portal: env.toy_wide_sum7 has 7 raw ABI argument slots, exceeding the interposition transport's 6-slot capacity" \
+    -- "    1: lib-3i portal: env.toy_wide_sum7 (i32, i32, i32, i32, i32, i32, i32) -> (i32) cannot be transported: 7 raw ABI argument slots, exceeding the interposition transport's 6-slot capacity" \
     -- "[Cage|widesig] FAIL: call returned normally" "[Grate|widesig] toy_wide_sum7 handler ran (should not happen)"
 
 # fail-closed-provenance-*: post-call pointer-provenance validation (issue


### PR DESCRIPTION
## Summary

- validate the complete lowered Wasm signature before installing a lib-3i portal
- accept only the scalar parameter and result types the transport carries
- reject unsupported vector/reference types, more than one result, and signatures exceeding the six-slot capacity
- include the symbol and complete lowered signature in rejection diagnostics
- add a maintained WAT-based checker that exercises the real `Linker::instance_dylink` path
- run the checker as part of the focused library-interposition suite

## Verification

- `make format`
- `make lind-boot`
- portal signature checker: 9 passed, 0 failed
- harness self-tests: 19 passed, 0 failed
- focused suite: 34 passed, 0 failed, 0 skipped
- `bash -n tests/grate-tests/lib-interpose/run_tests.sh`
- `git diff --check`

Closes #13.
